### PR TITLE
Flush per site cache

### DIFF
--- a/redis-cache.php
+++ b/redis-cache.php
@@ -18,7 +18,7 @@ class RedisObjectCache {
 
 	private $page;
 	private $screen = 'settings_page_redis-cache';
-	private $actions = array( 'enable-cache', 'disable-cache', 'flush-cache', 'update-dropin' );
+	private $actions = array( 'enable-cache', 'disable-cache', 'flush-cache', 'update-dropin', 'flush-site-cache' );
 
 	public function __construct() {
 
@@ -33,6 +33,12 @@ class RedisObjectCache {
 		add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_admin_styles' ) );
 		add_action( 'load-' . $this->screen, array( $this, 'do_admin_actions' ) );
 		add_action( 'load-' . $this->screen, array( $this, 'add_admin_page_notices' ) );
+		if ( is_multisite() ) {
+			add_filter( 'wpmu_blogs_columns', array( $this, 'add_redis_action_column' ) );
+			add_action( 'admin_head', array( $this, 'redis_column_width' ) );
+			add_action( 'manage_sites_custom_column', array( $this, 'add_redis_action' ), 10, 2 );
+			add_action( 'network_admin_notices', array( $this, 'network_admin_notices' ) );
+		}
 
 		add_filter( sprintf(
 			'%splugin_action_links_%s',
@@ -40,6 +46,32 @@ class RedisObjectCache {
 			plugin_basename( __FILE__ )
 		), array( $this, 'add_plugin_actions_links' ) );
 
+	}
+
+	public function add_redis_action_column( $columns ) {
+		$columns['redis'] = 'Redis Action';
+		return $columns;
+	}
+	public function add_redis_action( $column, $blog_id ) {
+		if ( $column === 'redis' ) {
+			echo '<a href="' . wp_nonce_url( network_admin_url( add_query_arg( array( 'action' => 'flush-site-cache', 'blog_id' => $blog_id ), $this->page ) ), 'flush-site-cache' ) . '">Flush Cache</a>';
+		}
+	}
+	public function redis_column_width() {
+		echo '<style type="text/css">';
+		echo '.column-redis { width:15% !important }';
+		echo '</style>';
+	}
+
+	public function network_admin_notices() {
+		if ( !isset( $_GET['result'] ) ) {
+			return false;
+		}
+		if ( $_GET['result'] === 'flush_success' ) {
+			echo '<div class="notice-success notice is-dismissible"><p>Flush succeed!</p></div>';
+		} else if ( $_GET['result'] === 'flush_error' ) {
+			echo '<div class="notice-error  notice is-dismissible"><p>Flush failed! There is an error or nothing to flush.</p></div>';
+		}
 	}
 
 	public function add_admin_menu_page() {
@@ -286,6 +318,15 @@ class RedisObjectCache {
 			}
 
 			if ( in_array( $action, $this->actions ) ) {
+
+				if ( $action === 'flush-site-cache' && isset( $_GET['blog_id'] ) ) {
+					if ( wp_cache_delete_branch( $_GET['blog_id'] ) ) {
+						wp_safe_redirect( network_admin_url( add_query_arg( 'result', 'flush_success', 'sites.php' ) ) );
+					} else {
+						wp_safe_redirect( network_admin_url( add_query_arg( 'result', 'flush_error', 'sites.php' ) ) );
+					}
+					exit;
+				}
 
 				$url = wp_nonce_url( network_admin_url( add_query_arg( 'action', $action, $this->page ) ), $action );
 


### PR DESCRIPTION
Redis Object Cache provides a Flush Cache button, however, it clears the entire DB. We have a multisite WordPress with thousands of blogs, and to flush all cache may lead performance problem to us. So I make some changes to flush per site cache. This feature is only available for network sites. A Flush Cache link will be added in each site line in Network Sites menu.

![flush_cache_action](https://cloud.githubusercontent.com/assets/1621293/16976789/14e7a9ea-4e84-11e6-92d8-062d53a7355a.PNG)
