### PR TITLE
Make WP_Object_Cache::$cache visibility public, fix WP-CLI etc. compatibility [1]

### DIFF
--- a/includes/object-cache.php
+++ b/includes/object-cache.php
@@ -266,7 +266,7 @@ class WP_Object_Cache {
 	 *
 	 * @var array
 	 */
-	private $cache = array();
+	public $cache = array();
 
 	/**
 	 * Name of the used Redis client


### PR DESCRIPTION
[1]: https://wordpress.org/support/topic/make-function-public-instead-of-private?replies=5

ElasticPress issue made more properties public. I'm not sure if it's necessary here or not. Perhaps makes sense to just go on-demand, one at a time.