### PR TITLE
Flush cache with key prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,10 @@ To adjust the configuration, define any of the following constants in your `wp-c
 * `WP_CACHE_KEY_SALT` (default: _not set_)
 
   Set the prefix for all cache keys. Useful in setups where multiple installs share a common `wp-config.php` or `$table_prefix`, to guarantee uniqueness of cache keys.
+  
+* `WP_REDIS_FLUSH_ONLY_KEY_SALT` (default: _not set_)
+
+If set to true AND `WP_CACHE_KEY_SALT` is also defined and non-empty, then flushing the cache will do a lua-scripted, wildcard flush on the redis database which will only delete keys that include `WP_CACHE_KEY_SALT`. If not defined or set to false, `flush` will flush the entire redis database.
 
 * `WP_REDIS_MAXTTL` (default: _not set_)
 

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ To adjust the configuration, define any of the following constants in your `wp-c
   
 * `WP_REDIS_FLUSH_ONLY_KEY_SALT` (default: _not set_)
 
-If set to true AND `WP_CACHE_KEY_SALT` is also defined and non-empty, then flushing the cache will do a lua-scripted, wildcard flush on the redis database which will only delete keys that include `WP_CACHE_KEY_SALT`. If not defined or set to false, `flush` will flush the entire redis database.
+  If set to true _and_ `WP_CACHE_KEY_SALT` is also defined and non-empty, then flushing the cache will do a lua-scripted, wildcard flush on the redis database which will only delete keys that include `WP_CACHE_KEY_SALT`. If not defined or set to false, `flush` will flush the entire redis database.
 
 * `WP_REDIS_MAXTTL` (default: _not set_)
 


### PR DESCRIPTION
See discussion in #52.

This patch seems to be working well on my production box. I think it's good to go for my use-case. I haven't tested it with multi-site and I haven't tested it with YUUGE numbers of keys, but I have tested it with 400K+ keys and it took < 1 second to flush them.

Yay lua.