### PR TITLE
Support for redis-sentinel config

### DIFF
--- a/includes/object-cache.php
+++ b/includes/object-cache.php
@@ -455,6 +455,12 @@ class WP_Object_Cache {
                     $options[ 'replication' ] = true;
                 }
 
+                if ( defined( 'WP_REDIS_SENTINEL' ) ) {
+                    $parameters = WP_REDIS_SERVERS;
+                    $options[ 'replication' ] = 'sentinel';
+                    $options[ 'service' ] = WP_REDIS_SENTINEL;
+                }                
+
                 if ( ( defined( 'WP_REDIS_SERVERS' ) || defined( 'WP_REDIS_CLUSTER' ) ) && defined( 'WP_REDIS_PASSWORD' ) ) {
                     $options[ 'parameters' ][ 'password' ] = WP_REDIS_PASSWORD;
                 }


### PR DESCRIPTION
the constant `WP_REDIS_SENTINEL` would be set to the value of the `service` configuration option to achieve a correct sentinel config for Predis.

e.g. from the documentation:

````php
$sentinels = ['tcp://10.0.0.1', 'tcp://10.0.0.2', 'tcp://10.0.0.3'];
$options   = ['replication' => 'sentinel', 'service' => 'mymaster'];

$client = new Predis\Client($sentinels, $options);
````