### PR TITLE
Force expiration time for keys higher than zero exporation time

### DIFF
--- a/includes/object-cache.php
+++ b/includes/object-cache.php
@@ -33,6 +33,8 @@ if ( ! defined( 'WP_REDIS_DISABLED' ) || ! WP_REDIS_DISABLED ) :
 function wp_cache_add( $key, $value, $group = '', $expiration = 0 ) {
     global $wp_object_cache;
 
+    $expiration = ( $expiration > 0 && defined( 'WP_REDIS_MAXTTL' ) ) ? intval( WP_REDIS_MAXTTL ) : $expiration;
+
     return $wp_object_cache->add( $key, $value, $group, $expiration );
 }
 
@@ -191,6 +193,8 @@ function wp_cache_init() {
  */
 function wp_cache_replace( $key, $value, $group = '', $expiration = 0 ) {
     global $wp_object_cache;
+
+    $expiration = ( $expiration > 0 && defined( 'WP_REDIS_MAXTTL' ) ) ? intval( WP_REDIS_MAXTTL ) : $expiration;
 
     return $wp_object_cache->replace( $key, $value, $group, $expiration );
 }


### PR DESCRIPTION
This solution did solve our problem with creation of 100000+ keys after few hours of caching.

That happend because the wordpress does cache the terms for a day and you cannot change that as it is in the core.

Currently we have around 10K keys and the website speed is very fast.

FYI it does keep the default expiration value if you don't define the custom TTL.