### PR TITLE
Extend and debug sentinel support

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,11 +101,12 @@ define( 'WP_REDIS_SERVERS', [
 ### Replication (Redis Sentinel)
 
 ```php
+define( 'WP_REDIS_CLIENT', 'predis' );
 define( 'WP_REDIS_SENTINEL', 'mymaster' );
-define( 'WP_REDIS_SERVERS', [
-    'tcp://127.0.0.1:5380',
-    'tcp://127.0.0.2:5381',
-    'tcp://127.0.0.3:5382',
+define( 'WP_REDIS_SENTINELS', [
+    'tcp://127.0.0.1:26379',
+    'tcp://127.0.0.2:26380',
+    'tcp://127.0.0.3:26381',
 ] );
 ```
 

--- a/includes/diagnostics.php
+++ b/includes/diagnostics.php
@@ -51,6 +51,8 @@ $constants = array(
     'WP_REDIS_GLOBAL_GROUPS',
     'WP_REDIS_IGNORED_GROUPS',
     'WP_CACHE_KEY_SALT',
+    'WP_REDIS_SENTINEL',
+    'WP_REDIS_SENTINELS',
 );
 
 foreach ( $constants as $constant ) {

--- a/includes/object-cache.php
+++ b/includes/object-cache.php
@@ -462,8 +462,11 @@ class WP_Object_Cache {
                     $parameters = WP_REDIS_CLUSTER;
                     $options[ 'cluster' ] = 'redis';
                 } elseif ( defined( 'WP_REDIS_SENTINEL' ) ) {
-                    $parameters = WP_REDIS_SERVERS;
-                    $options[ 'replication' ] = true;
+                    if ( !defined( 'WP_REDIS_SENTINELS' ) ) {
+                       throw new Exception;
+                    }
+                    $parameters = WP_REDIS_SENTINELS;
+                    $options[ 'replication' ] = 'sentinel';
                     $options[ 'service' ] = WP_REDIS_SENTINEL;
                 }
 

--- a/includes/servers-list.php
+++ b/includes/servers-list.php
@@ -110,7 +110,7 @@ class Servers_List extends WP_List_Table {
             $servers = WP_REDIS_SERVERS;
         }
 
-        if ( defined( 'WP_REDIS_SENTINELS' ) && defined( 'WP_REDIS_SENTINELS' ) ) {
+        if ( defined( 'WP_REDIS_SENTINEL' ) && defined( 'WP_REDIS_SENTINELS' ) ) {
             $servers = WP_REDIS_SENTINELS;
         }
 

--- a/includes/servers-list.php
+++ b/includes/servers-list.php
@@ -110,6 +110,10 @@ class Servers_List extends WP_List_Table {
             $servers = WP_REDIS_SERVERS;
         }
 
+        if ( defined( 'WP_REDIS_SENTINELS' ) && defined( 'WP_REDIS_SENTINELS' ) ) {
+            $servers = WP_REDIS_SENTINELS;
+        }
+
         if ( ! isset( $servers ) ) {
             $servers = array( $server );
         }

--- a/readme.txt
+++ b/readme.txt
@@ -113,11 +113,12 @@ __Replication (Master-Slave):__
 
 __Replication (Redis Sentinel):__
 
+    define( 'WP_REDIS_CLIENT', 'predis' );
     define( 'WP_REDIS_SENTINEL', 'mymaster' );
-    define( 'WP_REDIS_SERVERS', [
-        'tcp://127.0.0.1:5380',
-        'tcp://127.0.0.2:5381',
-        'tcp://127.0.0.3:5382',
+    define( 'WP_REDIS_SENTINELS', [
+        'tcp://127.0.0.1:26379',
+        'tcp://127.0.0.2:26380',
+        'tcp://127.0.0.3:26381',
     ] );
 
 __Sharding:__

--- a/redis-cache.php
+++ b/redis-cache.php
@@ -3,7 +3,7 @@
 Plugin Name: Redis Object Cache
 Plugin URI: https://wordpress.org/plugins/redis-cache/
 Description: A persistent object cache backend powered by Redis. Supports Predis, PhpRedis, HHVM, replication, clustering and WP-CLI.
-Version: 1.3.5
+Version: 1.3.6
 Text Domain: redis-cache
 Domain Path: /languages
 Author: Till Krüss


### PR DESCRIPTION
Fixes problems with Redis Sentinel support.

I opted to add a new constant: WP_REDIS_SENTINELS to reflect the fact that predis expects to be passed the sentinels, and then fetches the server configs from the sentinels. This has the added advantage of not being dependent on the order the elseifs come in.