### PR TITLE
Fix RedisCluster warnings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,8 @@ php:
 services:
   - redis-server
 
+before_install: pecl install redis
+
 install: travis_retry composer install --no-interaction --prefer-source
 
 script: vendor/bin/phpunit

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,10 @@
 language: php
 
 php:
-  - 5.6
-  - 7.0
   - hhvm
+  - 7.0
+  - 7.1
+  - 7.2
 
 services:
   - redis-server

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,9 @@ php:
   - 7.0
   - hhvm
 
+services:
+  - redis-server
+
 install: travis_retry composer install --no-interaction --prefer-source
 
 script: vendor/bin/phpunit

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,8 @@ php:
 services:
   - redis-server
 
-before_install: pecl install redis
+before_install:
+  - echo "extension = redis.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini
 
 install: travis_retry composer install --no-interaction --prefer-source
 

--- a/includes/object-cache.php
+++ b/includes/object-cache.php
@@ -491,7 +491,11 @@ class WP_Object_Cache
             }
 
             // Throws exception if Redis is unavailable
-            $this->redis->ping();
+            if (defined('WP_REDIS_CLUSTER') && strcasecmp('pecl', $client) === 0) {
+                $this->redis->ping(WP_REDIS_HOST);
+            } else {
+                $this->redis->ping();
+            }
 
             $this->redis_connected = true;
         } catch (Exception $exception) {

--- a/includes/object-cache.php
+++ b/includes/object-cache.php
@@ -424,9 +424,9 @@ class WP_Object_Cache
                 $this->redis_client = sprintf('PhpRedis (v%s)', phpversion('redis'));
 
                 if (defined('WP_REDIS_SHARDS')) {
-                    $this->redis = new RedisArray(WP_REDIS_CLUSTER);
+                    $this->redis = new RedisArray(array_values(WP_REDIS_CLUSTER));
                 } elseif (defined('WP_REDIS_CLUSTER')) {
-                    $this->redis = new RedisCluster(null, WP_REDIS_CLUSTER);
+                    $this->redis = new RedisCluster(null, array_values(WP_REDIS_CLUSTER));
                 } else {
                     $this->redis = new Redis();
 
@@ -492,7 +492,7 @@ class WP_Object_Cache
 
             // Throws exception if Redis is unavailable
             if (defined('WP_REDIS_CLUSTER') && strcasecmp('pecl', $client) === 0) {
-                $this->redis->ping(WP_REDIS_HOST);
+                $this->redis->ping(current(array_values(WP_REDIS_CLUSTER)));
             } else {
                 $this->redis->ping();
             }

--- a/includes/object-cache.php
+++ b/includes/object-cache.php
@@ -474,7 +474,7 @@ class WP_Object_Cache
                     $parameters = WP_REDIS_SERVERS;
                     $options[ 'replication' ] = true;
                 } elseif (defined('WP_REDIS_CLUSTER')) {
-                    $parameters = explode(',' WP_REDIS_CLUSTER);
+                    $parameters = explode(',', WP_REDIS_CLUSTER);
                     $options[ 'cluster' ] = 'redis';
                 }
 

--- a/includes/object-cache.php
+++ b/includes/object-cache.php
@@ -661,7 +661,7 @@ class WP_Object_Cache
             sleep($delay);
         }
 
-        $result = false;
+        $result = [];
         $this->cache = array();
 
         if ($this->redis_status()) {
@@ -678,23 +678,40 @@ class WP_Object_Cache
                     return i
                 ";
 
-                $result = $this->parse_redis_response($this->redis->eval(
-                    $script,
-                    $this->redis instanceof Predis\Client ? 0 : []
-                ));
+                if (defined('WP_REDIS_CLUSTER') && defined('WP_REDIS_CLIENT') && strcasecmp('pecl', WP_REDIS_CLIENT) === 0) {
+                    foreach($this->redis->_masters() as $master) {
+                        $redis = new Redis();
+                        $redis->connect($master[0], $master[1]);
+                        $result[] = $this->parse_redis_response($this->redis->eval($script));
+                        unset($redis);
+                    }
+                } else {
+                    $result[] = $this->parse_redis_response(
+                        $this->redis->eval(
+                            $script,
+                            $this->redis instanceof Predis\Client ? 0 : []
+                        )
+                    );
+                }
             } else {
                 if (defined('WP_REDIS_CLUSTER') && defined('WP_REDIS_CLIENT') && strcasecmp('pecl', WP_REDIS_CLIENT) === 0) {
                     foreach($this->redis->_masters() as $master) {
-                        $result = $this->parse_redis_response($this->redis->flushdb($master));
+                        $result[] = $this->parse_redis_response($this->redis->flushdb($master));
                     }
                 } else {
-                    $result = $this->parse_redis_response($this->redis->flushdb());
+                    $result[] = $this->parse_redis_response($this->redis->flushdb());
                 }
             }
 
             if (function_exists('do_action')) {
-                do_action('redis_object_cache_flush', $result, $delay, $selective, $salt);
+                foreach($result as $response) {
+                    do_action('redis_object_cache_flush', $result, $delay, $selective, $salt);
+                }
             }
+        }
+
+        if (empty($result)) {
+            $result = false;
         }
 
         return $result;
@@ -974,7 +991,7 @@ class WP_Object_Cache
         $salt = defined('WP_CACHE_KEY_SALT') ? trim(WP_CACHE_KEY_SALT) : '';
         $prefix = in_array($group, $this->global_groups) ? $this->global_prefix : $this->blog_prefix;
 
-        return "{$salt}{$prefix}:{$group}:{$key}";
+        return "{{$salt}{$prefix}}:{$group}:{$key}";
     }
 
     /**

--- a/includes/object-cache.php
+++ b/includes/object-cache.php
@@ -684,9 +684,8 @@ class WP_Object_Cache
                 ));
             } else {
                 if (defined('WP_REDIS_CLUSTER') && defined('WP_REDIS_CLIENT') && strcasecmp('pecl', WP_REDIS_CLIENT) === 0) {
-                    foreach(WP_REDIS_CLUSTER as $host) {
-                        $parsed_host = parse_url($host);
-                        $result = $this->parse_redis_response($this->redis->flushdb($parsed_host['host']));
+                    foreach($this->redis->_masters() as $master) {
+                        $result = $this->parse_redis_response($this->redis->flushdb($master));
                     }
                 } else {
                     $result = $this->parse_redis_response($this->redis->flushdb());

--- a/includes/object-cache.php
+++ b/includes/object-cache.php
@@ -424,9 +424,9 @@ class WP_Object_Cache
                 $this->redis_client = sprintf('PhpRedis (v%s)', phpversion('redis'));
 
                 if (defined('WP_REDIS_SHARDS')) {
-                    $this->redis = new RedisArray(array_values(WP_REDIS_CLUSTER));
+                    $this->redis = new RedisArray(explode(',', WP_REDIS_CLUSTER));
                 } elseif (defined('WP_REDIS_CLUSTER')) {
-                    $this->redis = new RedisCluster(null, array_values(WP_REDIS_CLUSTER));
+                    $this->redis = new RedisCluster(null, explode(',', WP_REDIS_CLUSTER));
                 } else {
                     $this->redis = new Redis();
 

--- a/includes/object-cache.php
+++ b/includes/object-cache.php
@@ -474,7 +474,7 @@ class WP_Object_Cache
                     $parameters = WP_REDIS_SERVERS;
                     $options[ 'replication' ] = true;
                 } elseif (defined('WP_REDIS_CLUSTER')) {
-                    $parameters = WP_REDIS_CLUSTER;
+                    $parameters = explode(',' WP_REDIS_CLUSTER);
                     $options[ 'cluster' ] = 'redis';
                 }
 

--- a/includes/object-cache.php
+++ b/includes/object-cache.php
@@ -685,7 +685,8 @@ class WP_Object_Cache
             } else {
                 if (defined('WP_REDIS_CLUSTER') && defined('WP_REDIS_CLIENT') && strcasecmp('pecl', WP_REDIS_CLIENT) === 0) {
                     foreach(WP_REDIS_CLUSTER as $host) {
-                        $result = $this->parse_redis_response($this->redis->flushdb($host));
+                        $parsed_host = parse_url($host);
+                        $result = $this->parse_redis_response($this->redis->flushdb($parsed_host['host']));
                     }
                 } else {
                     $result = $this->parse_redis_response($this->redis->flushdb());

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit backupGlobals="false"
          backupStaticAttributes="false"
-         bootstrap="vendor/autoload.php"
+         bootstrap="tests/bootstrap.php"
          colors="true"
          convertErrorsToExceptions="true"
          convertNoticesToExceptions="true"

--- a/tests/ObjectCacheTest.php
+++ b/tests/ObjectCacheTest.php
@@ -13,8 +13,10 @@ class ObjectCacheTest extends PHPUnit_Framework_TestCase
     public function testRedisFlush()
     {
         $wpObjectCache = new WP_Object_Cache(false);
-        $result = $wpObjectCache->flush();
-        $this->assertTrue($result);
+        $results = $wpObjectCache->flush();
+        foreach($results as $result) {
+            $this->assertTrue($result);
+        }
     }
 
     public function testRedisClusterInstance()

--- a/tests/ObjectCacheTest.php
+++ b/tests/ObjectCacheTest.php
@@ -13,9 +13,10 @@ class ObjectCacheTest extends PHPUnit_Framework_TestCase
     public function testRedisClusterInstance()
     {
         // TODO: remove if Travis supports Redis Cluster
-        $this->expectException(RedisClusterException::class);
+       //  $this->expectException(RedisClusterException::class);
 
-        define('WP_REDIS_CLUSTER', ['127.0.0.1']);
+        define('WP_REDIS_CLUSTER', '127.0.0.1');
+        define('WP_REDIS_HOST', '127.0.0.1');
         $wpObjectCache = new WP_Object_Cache(false);
         $this->assertNotEmpty($wpObjectCache->redis_instance());
     }

--- a/tests/ObjectCacheTest.php
+++ b/tests/ObjectCacheTest.php
@@ -1,9 +1,22 @@
 <?php
 
+require_once __DIR__ . '/../includes/object-cache.php';
+
 class ObjectCacheTest extends PHPUnit_Framework_TestCase
 {
-    public function testNothing()
+    public function testRedisInstance()
     {
-        $this->assertTrue(true);
+        $wpObjectCache = new WP_Object_Cache(false);
+        $this->assertNotEmpty($wpObjectCache->redis_instance());
+    }
+
+    public function testRedisClusterInstance()
+    {
+        // TODO: remove if Travis supports Redis Cluster
+        $this->expectException(RedisClusterException::class);
+
+        define('WP_REDIS_CLUSTER', ['127.0.0.1']);
+        $wpObjectCache = new WP_Object_Cache(false);
+        $this->assertNotEmpty($wpObjectCache->redis_instance());
     }
 }

--- a/tests/ObjectCacheTest.php
+++ b/tests/ObjectCacheTest.php
@@ -13,7 +13,11 @@ class ObjectCacheTest extends PHPUnit_Framework_TestCase
     public function testRedisClusterInstance()
     {
         // TODO: remove if Travis supports Redis Cluster
-       //  $this->expectException(RedisClusterException::class);
+        if (strcasecmp('hhvm', phpversion()) !== 0) {
+            $this->expectException(RedisClusterException::class);
+        }
+
+        echo phpversion() . PHP_EOL;
 
         define('WP_REDIS_CLUSTER', '127.0.0.1');
         define('WP_REDIS_HOST', '127.0.0.1');

--- a/tests/ObjectCacheTest.php
+++ b/tests/ObjectCacheTest.php
@@ -13,11 +13,9 @@ class ObjectCacheTest extends PHPUnit_Framework_TestCase
     public function testRedisClusterInstance()
     {
         // TODO: remove if Travis supports Redis Cluster
-        if (strcasecmp('hhvm', phpversion()) !== 0) {
+        if (stripos(phpversion(), 'hhvm') === false) {
             $this->expectException(RedisClusterException::class);
         }
-
-        echo phpversion() . PHP_EOL;
 
         define('WP_REDIS_CLUSTER', '127.0.0.1');
         define('WP_REDIS_HOST', '127.0.0.1');

--- a/tests/ObjectCacheTest.php
+++ b/tests/ObjectCacheTest.php
@@ -10,6 +10,13 @@ class ObjectCacheTest extends PHPUnit_Framework_TestCase
         $this->assertNotEmpty($wpObjectCache->redis_instance());
     }
 
+    public function testRedisFlush()
+    {
+        $wpObjectCache = new WP_Object_Cache(false);
+        $result = $wpObjectCache->flush();
+        $this->assertTrue($result);
+    }
+
     public function testRedisClusterInstance()
     {
         // TODO: remove if Travis supports Redis Cluster
@@ -17,7 +24,7 @@ class ObjectCacheTest extends PHPUnit_Framework_TestCase
             $this->expectException(RedisClusterException::class);
         }
 
-        define('WP_REDIS_CLUSTER', '127.0.0.1');
+        define('WP_REDIS_CLUSTER', ['127.0.0.1']);
         define('WP_REDIS_HOST', '127.0.0.1');
         $wpObjectCache = new WP_Object_Cache(false);
         $this->assertNotEmpty($wpObjectCache->redis_instance());

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,0 +1,4 @@
+<?php
+
+// future additional setup work here
+include __DIR__ . '/../vendor/autoload.php';


### PR DESCRIPTION
A warning is generated when using a `RedisCluster` as the datasource for object cache with PECL Redis:
```
PHP Warning:  RedisCluster::ping() expects exactly 1 parameter, 0 given in /var/www/sportshub/releases/20180402235221/web/app/object-cache.php on line 494
```

This PR updates object-cache.php to ping with a host when in cluster mode. This avoids continuous PHP warnings in logs. I chose `WP_REDIS_HOST` as the constant to use since it's required in single node implementations and makes sense if you're using a hosting provider that only requires you know the endpoint to a single server to make use of an entire Redis Cluster, like AWS: https://docs.aws.amazon.com/AmazonElastiCache/latest/UserGuide/Endpoints.html#Endpoints.Find.RedisCluster

Of course we could use a different constant, or a random entry from the seed nodes passed in as well, since it's just checking to see if the connection is alive.