### PR TITLE
igbinary serializer support is added.

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,13 @@ To adjust the configuration, define any of the following constants in your `wp-c
 
   Set to `true` to disable the object cache at runtime.
 
+* `WP_REDIS_IGBINARY` (default: _not set_)
+
+  Uses [igbinary](https://github.com/igbinary/igbinary) serializer that serialize data into a binary
+  form and thus reduce data size compared with php's `serialize()` function. Before using this
+  parameter ensure that php-igbinary extension is installed and redis database is
+  [flush](https://redis.io/commands/flushdb)ed.
+
 
 ## Replication & Clustering
 

--- a/includes/object-cache.php
+++ b/includes/object-cache.php
@@ -1111,6 +1111,10 @@ class WP_Object_Cache
      */
     protected function maybe_unserialize($original)
     {
+        if (defined('WP_REDIS_IGBINARY') && WP_REDIS_IGBINARY) {
+            return igbinary_unserialize($original);
+        }
+
         // don't attempt to unserialize data that wasn't serialized going in
         if ($this->is_serialized($original)) {
             return @unserialize($original);
@@ -1126,6 +1130,10 @@ class WP_Object_Cache
      */
     protected function maybe_serialize($data)
     {
+        if (defined('WP_REDIS_IGBINARY') && WP_REDIS_IGBINARY) {
+            return igbinary_serialize($data);
+        }
+
         if (is_array($data) || is_object($data)) {
             return serialize($data);
         }

--- a/readme.txt
+++ b/readme.txt
@@ -87,6 +87,13 @@ To adjust the configuration, define any of the following constants in your `wp-c
 
     Set to `true` to disable the object cache at runtime.
 
+  * `WP_REDIS_IGBINARY` (default: _not set_)
+
+    Uses [igbinary](https://github.com/igbinary/igbinary) serializer that serialize data into a binary
+    form and thus reduce data size compared with php's `serialize()` function. Before using this
+    parameter ensure that php-igbinary extension is installed and redis database is
+    [flush](https://redis.io/commands/flushdb)ed.
+      
 
 == Replication & Clustering ==
 


### PR DESCRIPTION
igbinary serializer is faster than php's serialize() and it also
reduces stored data converting them into a binary form.
This commit brings a new WP_REDIS_IGBINARY constant which enables
igbinary serializer for Redis object cache.