### PR TITLE
Rename `redis_object_cache_get` filter

### DIFF
--- a/includes/object-cache.php
+++ b/includes/object-cache.php
@@ -750,7 +750,7 @@ class WP_Object_Cache
 
         if (function_exists('apply_filters') && function_exists('has_filter')) {
             if (has_filter('redis_object_cache_get')) {
-                return apply_filters('redis_object_cache_get', $value, $key, $group, $force, $found);
+                return apply_filters('redis_object_cache_get_value', $value, $key, $group, $force, $found);
             }
         }
 


### PR DESCRIPTION
Shouldn't match the `redis_object_cache_get` action. Renaming to
`redis_object_cache_get_value`

Fixes #90