### PR TITLE
Adds filter to customize the cache expiration

### DIFF
--- a/includes/object-cache.php
+++ b/includes/object-cache.php
@@ -600,7 +600,7 @@ class WP_Object_Cache
                 return false;
             }
 
-            $expiration = apply_filters('redis_cache_expiration', $this->validate_expiration($expiration), $key, $value, $group);
+            $expiration = apply_filters('redis_cache_expiration', $this->validate_expiration($expiration), $key, $group);
 
             if ($expiration) {
                 $result = $this->parse_redis_response($this->redis->setex($derived_key, $expiration, $this->maybe_serialize($value)));

--- a/includes/object-cache.php
+++ b/includes/object-cache.php
@@ -600,7 +600,7 @@ class WP_Object_Cache
                 return false;
             }
 
-            $expiration = $this->validate_expiration($expiration);
+            $expiration = apply_filters('redis_cache_expiration', $this->validate_expiration($expiration), $key, $value, $group);
 
             if ($expiration) {
                 $result = $this->parse_redis_response($this->redis->setex($derived_key, $expiration, $this->maybe_serialize($value)));


### PR DESCRIPTION
This plugin adds a filter to allowing the customization of the cache expiration setting depending on the inserted key/value in the database.

Using this, we could solve problems like the one described in https://wordpress.org/support/topic/expiration-date-5/