### PR TITLE
The use of PING command was removed and bug was fixed.

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,12 +131,6 @@ define( 'WP_REDIS_CLUSTER', [
     'tcp://127.0.0.1:6379?alias=node-01',
     'tcp://127.0.0.2:6379?alias=node-02',
     'tcp://127.0.0.3:6379?alias=node-03',
-    'tcp://127.0.0.4:6379?alias=node-04',
-    'tcp://127.0.0.5:6379?alias=node-05',
-    'tcp://127.0.0.6:6379?alias=node-06',
-    'tcp://127.0.0.7:6379?alias=node-07',
-    'tcp://127.0.0.8:6379?alias=node-08',
-    'tcp://127.0.0.9:6379?alias=node-09',
 ] );
 ```
 

--- a/README.md
+++ b/README.md
@@ -128,8 +128,15 @@ define( 'WP_REDIS_SHARDS', [
 
 ```php
 define( 'WP_REDIS_CLUSTER', [
-    'tcp://127.0.0.1:6379?database=15&alias=node-01',
-    'tcp://127.0.0.2:6379?database=15&alias=node-02',
+    'tcp://127.0.0.1:6379?alias=node-01',
+    'tcp://127.0.0.2:6379?alias=node-02',
+    'tcp://127.0.0.3:6379?alias=node-03',
+    'tcp://127.0.0.4:6379?alias=node-04',
+    'tcp://127.0.0.5:6379?alias=node-05',
+    'tcp://127.0.0.6:6379?alias=node-06',
+    'tcp://127.0.0.7:6379?alias=node-07',
+    'tcp://127.0.0.8:6379?alias=node-08',
+    'tcp://127.0.0.9:6379?alias=node-09',
 ] );
 ```
 

--- a/includes/diagnostics.php
+++ b/includes/diagnostics.php
@@ -13,7 +13,6 @@ $info[ 'Drop-in' ] = $dropin ? 'Valid' : 'Invalid';
 if ( $dropin ) {
     try {
         $cache = new WP_Object_Cache( false );
-        $info[ 'Ping' ] = $cache->redis_instance()->ping();
     } catch ( Exception $exception ) {
         $info[ 'Connection Exception' ] = sprintf( '%s (%s)', $exception->getMessage(), get_class( $exception ) );
     }

--- a/includes/diagnostics.php
+++ b/includes/diagnostics.php
@@ -13,7 +13,7 @@ $info[ 'Drop-in' ] = $dropin ? 'Valid' : 'Invalid';
 if ( $dropin ) {
     try {
         $cache = new WP_Object_Cache( false );
-        $info[ 'Ping' ] = defined( 'WP_REDIS_CLUSTER' ) 'Not supported' ? $cache->redis_instance()->ping();
+        $info[ 'Ping' ] = defined( 'WP_REDIS_CLUSTER' ) ? 'Not supported' : $cache->redis_instance()->ping();
     } catch ( Exception $exception ) {
         $info[ 'Connection Exception' ] = sprintf( '%s (%s)', $exception->getMessage(), get_class( $exception ) );
     }

--- a/includes/diagnostics.php
+++ b/includes/diagnostics.php
@@ -13,6 +13,7 @@ $info[ 'Drop-in' ] = $dropin ? 'Valid' : 'Invalid';
 if ( $dropin ) {
     try {
         $cache = new WP_Object_Cache( false );
+        $info[ 'Ping' ] = defined( 'WP_REDIS_CLUSTER' ) 'Not supported' ? $cache->redis_instance()->ping();
     } catch ( Exception $exception ) {
         $info[ 'Connection Exception' ] = sprintf( '%s (%s)', $exception->getMessage(), get_class( $exception ) );
     }

--- a/includes/object-cache.php
+++ b/includes/object-cache.php
@@ -490,9 +490,6 @@ class WP_Object_Cache
                 $this->redis_client .= sprintf(' (v%s)', Predis\Client::VERSION);
             }
 
-            // Throws exception if Redis is unavailable
-            $this->redis->ping();
-
             $this->redis_connected = true;
         } catch (Exception $exception) {
 

--- a/includes/object-cache.php
+++ b/includes/object-cache.php
@@ -490,6 +490,10 @@ class WP_Object_Cache
                 $this->redis_client .= sprintf(' (v%s)', Predis\Client::VERSION);
             }
 
+            if (! defined('WP_REDIS_CLUSTER')) {
+                $this->redis->ping(); // Throws exception if Redis is unavailable
+            }
+
             $this->redis_connected = true;
         } catch (Exception $exception) {
 


### PR DESCRIPTION
Redis-Object-Cache plug-in does not support redis-cluster adequately. It is wrong to operate the cluster in the wrong way. You use redis-cluster in the same way as singleton, because the characteristics of redis-cluster determine that some operations are invalid, such as ping, modifying the following code of object-cache.php or diagnostics.php to recover from failure.

- The use of PING command was removed and bug was fixed
- In addition, since redis-cluster mode cannot select database db numbers greater than 0, it is not meaningful to explicitly specify database db number operations in redis-cluster mode. I have changed the relevant parts of redis object cache documents, please update them.
