### PR TITLE
typo

### DIFF
--- a/includes/object-cache.php
+++ b/includes/object-cache.php
@@ -417,7 +417,7 @@ class WP_Object_Cache
         }
 
         if (defined('WP_REDIS_UNFLUSHABLE_GROUPS') && is_array(WP_REDIS_UNFLUSHABLE_GROUPS)) {
-            $this->unflashable_groups = WP_REDIS_UNFLUSHABLE_GROUPS;
+            $this->unflushable_groups = WP_REDIS_UNFLUSHABLE_GROUPS;
         }
 
         $client = defined('WP_REDIS_CLIENT') ? WP_REDIS_CLIENT : null;


### PR DESCRIPTION
Caught the Flash ;)

fixed a typo preventing the `WP_REDIS_UNFLUSHABLE_GROUPS` constant being considered