### PR TITLE
more secure flush scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
+/.vscode
 /vendor
 composer.lock


### PR DESCRIPTION
Replaced the `lua_flush_script` method with a method returning a closure using the `unflushable_groups` property as lua-argument and differentiating between `pecl` and `predis` argument order of the respective `eval` methods.