### PR TITLE
Null key separator

### DIFF
--- a/includes/object-cache.php
+++ b/includes/object-cache.php
@@ -1144,7 +1144,10 @@ LUA;
         $salt = defined('WP_CACHE_KEY_SALT') ? trim(WP_CACHE_KEY_SALT) : '';
         $prefix = in_array($group, $this->global_groups) ? $this->global_prefix : $this->blog_prefix;
 
-        return "{$salt}{$prefix}:{$group}:{$key}";
+	    $sep = chr(0);
+	    $group = strtr( $group, $sep, '' );
+
+        return "{$salt}{$prefix}{$sep}{$group}{$sep}{$key}";
     }
 
     /**

--- a/includes/object-cache.php
+++ b/includes/object-cache.php
@@ -809,7 +809,8 @@ LUA;
         $salt_length = strlen($salt);
 
         $unflushable = array_map(function ($group) {
-            return ":{$group}:";
+            $sep = chr(0);
+            return "{$sep}{$group}{$sep}";
         }, $this->unflushable_groups);
 
         $unflushable = sprintf("{'%s'}", implode('\',\'', $unflushable));

--- a/includes/object-cache.php
+++ b/includes/object-cache.php
@@ -1143,9 +1143,8 @@ LUA;
 
         $salt = defined('WP_CACHE_KEY_SALT') ? trim(WP_CACHE_KEY_SALT) : '';
         $prefix = in_array($group, $this->global_groups) ? $this->global_prefix : $this->blog_prefix;
-
-	    $sep = chr(0);
-	    $group = strtr( $group, $sep, '' );
+        $sep = chr(0);
+        $group = strtr( $group, $sep, '' );
 
         return "{$salt}{$prefix}{$sep}{$group}{$sep}{$key}";
     }


### PR DESCRIPTION
Problem:
Using the `:` as separator building the redis key might cause issues if a group name contains that separator.

Solution:
Researched a bit and came to the conclusion that it would be best to have the keys separated by the null-char as its usage should be far less than `:` and you might argue that removing a null-char during key-sanitization is a good thing.

Redis is handling that key just fine using `\x00` so retrieving the value is not an issue.