### PR TITLE
Don't ping Redis clusters

### DIFF
--- a/includes/object-cache.php
+++ b/includes/object-cache.php
@@ -531,9 +531,7 @@ class WP_Object_Cache
                 $this->redis_client .= sprintf(' (v%s)', Predis\Client::VERSION);
             }
 
-            if (defined('WP_REDIS_CLUSTER')) {
-                $this->redis->ping(current(array_values(WP_REDIS_CLUSTER)));
-            } else {
+            if (!defined('WP_REDIS_CLUSTER')) {
                 $this->redis->ping();
             }
 


### PR DESCRIPTION
In Redis Object Cache mode, you can't use Ping command. Note that I've corrected it once and I don't know why it was restored by you again.