### PR TITLE
Plesk phpredis fix

### DIFF
--- a/includes/object-cache.php
+++ b/includes/object-cache.php
@@ -789,6 +789,16 @@ class WP_Object_Cache
     {
         $rep_squotes = array('\'' => '\\\'');
         $salt        = strtr($salt, $rep_squotes);
+        if ( ! $this->unflushable_groups ) {
+            return <<<EOT
+                local i = 0
+                for _,k in ipairs(redis.call('keys', '{$salt}*')) do
+                    redis.call('del', k)
+                    i = i + 1
+                end
+                return i
+EOT;
+        }
         $salt_length = strlen($salt);
         $unflushable = array_map(
             function($group) use ($rep_squotes) {
@@ -797,7 +807,7 @@ class WP_Object_Cache
             $this->unflushable_groups
         );
         $unflushable = '{\'' . implode('\',\'', $unflushable) . '\'}';
-        return "            
+        return <<<EOT
             local cur = 0
             local i = 0
             local unf = {$unflushable}
@@ -821,7 +831,7 @@ class WP_Object_Cache
                 end
             until 0 == cur
             return i
-        ";
+EOT;
     }
 
     /**


### PR DESCRIPTION
As mentioned in https://github.com/tillkruss/redis-cache/issues/123 plesk ships with phpredis version 3.0.0. As this version only supports 5 arguments for the redis `connection` method trying to call it with the 6th argument (retry_timeout) will result in a silent connection failure.

Digging into the phpredis source I found that the 6th argument was introduced in version 3.1.3 so this fix checks the installed version to that specific one and adds the 6th argument only if applicable.