### PR TITLE
Flush don't work with WP_REDIS_SELECTIVE_FLUSH set to TRUE (issue #126)

### DIFF
--- a/includes/object-cache.php
+++ b/includes/object-cache.php
@@ -845,6 +845,7 @@ class WP_Object_Cache
     {
         return function () use ($salt) {
             $script = <<<LUA
+                redis.replicate_commands()
                 local cur = 0
                 local i = 0
                 local tmp
@@ -885,6 +886,7 @@ LUA;
             }, $this->unflushable_groups);
 
             $script = <<<LUA
+                redis.replicate_commands()
                 local cur = 0
                 local i = 0
                 local d, tmp


### PR DESCRIPTION
This PR fix the LUA error, reported in issue #126 

`(error) ERR Error running script (call to f_523831630e0cc0dbf20c9141913c81f1bec591ba): @user_script:9: @user_script: 9: Write commands not allowed after non deterministic commands. Call redis.replicate_commands() at the start of your script in order to switch to single commands replication mode.`

PS: I don't know if this is the correct solution, I don't have much knowledge of redis, I try to read https://redis.io/commands/eval but I can't figure out.