### PR TITLE
added lua script redis version check

### DIFF
--- a/includes/diagnostics.php
+++ b/includes/diagnostics.php
@@ -6,6 +6,7 @@ $info = $plugins = $dropins = array();
 $dropin = $this->validate_object_cache_dropin() && ( ! defined('WP_REDIS_DISABLED') || ! WP_REDIS_DISABLED );
 
 $info[ 'Status' ] = $this->get_status();
+$info[ 'Redis Version' ] = $this->get_redis_version() ?: 'Unknown';
 $info[ 'Client' ] = $this->get_redis_client_name();
 
 $info[ 'Drop-in' ] = $dropin ? 'Valid' : 'Invalid';

--- a/redis-cache.php
+++ b/redis-cache.php
@@ -185,6 +185,21 @@ class RedisObjectCache {
 
     }
 
+    public function get_redis_version() {
+
+        global $wp_object_cache;
+
+        if ( defined( 'WP_REDIS_DISABLED' ) && WP_REDIS_DISABLED ) {
+            return;
+        }
+
+        if ( $this->validate_object_cache_dropin() ) {
+            return $wp_object_cache->redis_version();
+        }
+
+        return;
+    }
+
     public function get_redis_client_name() {
 
         global $wp_object_cache;


### PR DESCRIPTION
As mentioned in https://github.com/tillkruss/redis-cache/pull/127

Added a version check to the `redis.replicate_commands()` LUA command as it is not needed in redis versions prior to 3.2 and since 5.0.
Additionally the actual redis version was not tracked before so I added the functionality and displayed it in the diagnostics section.