### PR TITLE
Removed strtolower in build key method to fix LUA scripts

### DIFF
--- a/includes/object-cache.php
+++ b/includes/object-cache.php
@@ -1264,7 +1264,7 @@ LUA;
 
         $prefix = trim($prefix, '_-:$');
 
-        return strtolower("{$salt}{$prefix}:{$group}:{$key}");
+        return "{$salt}{$prefix}:{$group}:{$key}";
     }
 
     /**


### PR DESCRIPTION
Fix for https://github.com/tillkruss/redis-cache/issues/130

Chose the simpler method of removing the `strtolower` function as it will lower complexity in favor of transforming the salt in the LUA scripts as well.