### PR TITLE
hide notice on missing read_timeout parameter

### DIFF
--- a/includes/object-cache.php
+++ b/includes/object-cache.php
@@ -550,7 +550,7 @@ class WP_Object_Cache
                     $options['cluster'] = 'redis';
 				}
 
-                if ($parameters['read_timeout']) {
+                if (isset($parameters['read_timeout']) && $parameters['read_timeout']) {
                     $parameters['read_write_timeout'] = $parameters['read_timeout'];
                 }
 


### PR DESCRIPTION
If notices are shown on pages, the application can break due to "headers already sent" PHP error.
This fix the problem.