### PR TITLE
wp cache flush failed due to glob pattern in salt when selective_flush set as true

### DIFF
--- a/includes/object-cache.php
+++ b/includes/object-cache.php
@@ -882,7 +882,15 @@ class WP_Object_Cache
     }
 
     protected function glob_quote($string) {
-        return str_replace(['[', '*', '?'], ['[[]', '[*]', '[?]'], $string);
+        $characters = ['*', '+', '?', '!', '{', '}', '[', ']', '(', ')', '|', '@'];
+        
+        return str_replace(
+            $characters,
+            array_map(function ($character) {
+                return "[{$character}]";
+            }, $characters),
+            $string
+        );
     }
 
     /**

--- a/includes/object-cache.php
+++ b/includes/object-cache.php
@@ -881,6 +881,10 @@ class WP_Object_Cache
         }
     }
 
+    protected function glob_quote($string) {
+        return str_replace(['[', '*', '?'], ['[[]', '[*]', '[?]'], $string);
+    }
+
     /**
      * Returns a closure ready to be called to flush selectively ignoring unflushable groups.
      *
@@ -889,6 +893,8 @@ class WP_Object_Cache
      */
     protected function lua_flush_closure($salt)
     {
+        $salt = $this->glob_quote($salt);
+
         return function () use ($salt) {
             $script = <<<LUA
                 local cur = 0
@@ -927,6 +933,8 @@ LUA;
      */
     protected function lua_flush_extended_closure($salt)
     {
+        $salt = $this->glob_quote($salt);
+
         return function () use ($salt) {
             $salt_length = strlen($salt);
 


### PR DESCRIPTION
**fixed**
when run "wp cache flush" and WP_REDIS_SELECTIVE_FLUSH set as true, the Redis fails to flush a cache due to salt contains a glob pattern.

**added**
glob_quote.
