### PR TITLE
Optional HTML footer with stats/diagnostics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [Unreleased]
+
+- Fixed MaxTTL warning condition
+
 ## 1.5.8
 
 - Added warning message about invalid MaxTTL

--- a/includes/admin-page.css
+++ b/includes/admin-page.css
@@ -5,36 +5,6 @@
     padding-bottom: 7px;
 }
 
-.wrap .button.delete {
-    background: #d54e21;
-    border-color: #a83d1a;
-    color: white;
-    -webkit-box-shadow: inset 0 1px 0 #e68260, 0 1px 0 rgba(0, 0, 0, 0.15);
-    box-shadow: inset 0 1px 0 #e68260, 0 1px 0 rgba(0, 0, 0, 0.15);
-}
-
-.wrap .button.delete:hover,
-.wrap .button.delete:focus {
-    background: #c7491f;
-    border-color: #923517;
-    color: white;
-}
-
-.wrap .button.delete:focus {
-    box-shadow: inset 0 1px 0 #e3704a,
-        0 0 0 1px #d54e21,
-        0 0 2px 1px rgba( 30, 140, 190, .8 );
-}
-
-.wrap .button.delete:active {
-    background: #a83d1a;
-    border-color: #923517;
-    color: white;
-    box-shadow: inset 0 2px 5px -3px rgba( 0, 0, 0, 0.5 ),
-        0 0 0 1px #d54e21,
-        0 0 2px 1px rgba( 30, 140, 190, .8 );
-}
-
 .settings_page_redis-cache .card,
 .settings_page_redis-cache br.clearfix {
     display: none;

--- a/includes/admin-page.php
+++ b/includes/admin-page.php
@@ -82,7 +82,7 @@
                     <td>
                         <code><?php echo esc_html( $redisMaxTTL ); ?></code>
 
-                        <?php if ( ! is_int( $redisMaxTTL ) && ! ctype_digit( $redisMaxTTL ) !== 0 ) : ?>
+                        <?php if ( ! is_int( $redisMaxTTL ) && ! ctype_digit( $redisMaxTTL ) ) : ?>
                             <p class="description" style="color: #d54e21;">
                                 <?php _e( 'This doesn’t appear to be a valid number.', 'redis-cache' ); ?>
                             </p>

--- a/includes/admin-page.php
+++ b/includes/admin-page.php
@@ -102,7 +102,7 @@
             <?php if ( ! $this->object_cache_dropin_exists() ) : ?>
                 <a href="<?php echo wp_nonce_url( network_admin_url( add_query_arg( 'action', 'enable-cache', $this->page ) ), 'enable-cache' ); ?>" class="button button-primary button-large"><?php _e( 'Enable Object Cache', 'redis-cache' ); ?></a>
             <?php elseif ( $this->validate_object_cache_dropin() ) : ?>
-                <a href="<?php echo wp_nonce_url( network_admin_url( add_query_arg( 'action', 'disable-cache', $this->page ) ), 'disable-cache' ); ?>" class="button button-secondary button-large delete"><?php _e( 'Disable Object Cache', 'redis-cache' ); ?></a>
+                <a href="<?php echo wp_nonce_url( network_admin_url( add_query_arg( 'action', 'disable-cache', $this->page ) ), 'disable-cache' ); ?>" class="button button-secondary button-large"><?php _e( 'Disable Object Cache', 'redis-cache' ); ?></a>
             <?php endif; ?>
 
         </p>


### PR DESCRIPTION
- [x] Show stats when `WP_DEBUG` is enabled
- [ ] Show stats via `WP_REDIS_*` constant
- [ ] Show stats via secure URL parameter
- [ ] Split hits/missing: Redis and in-memory
- [ ] Refine comment template (one liner?)

Resolves #154

