### PR TITLE
Fix incr/decr result

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Prevent rare deprecation warning when setting up new site
 - Prevent PHP 8.2 deprecation in `wp-activate.php`
+- Fixed (in|de)crement not working with igbinary
 
 ## 2.6.3
 

--- a/includes/object-cache.php
+++ b/includes/object-cache.php
@@ -2416,6 +2416,7 @@ LUA;
 
             if ( $result ) {
                 $this->add_to_internal_cache( $derived_key, $value );
+                $result = $value;
             }
         } catch ( Exception $exception ) {
             $this->handle_exception( $exception );
@@ -2477,6 +2478,7 @@ LUA;
 
             if ( $result ) {
                 $this->add_to_internal_cache( $derived_key, $value );
+                $result = $value;
             }
         } catch ( Exception $exception ) {
             $this->handle_exception( $exception );


### PR DESCRIPTION
Fixes #574

In my previous PR I missed that `wp_cache_incr` and `wp_cache_decr` returns updated value