### PR TITLE
Delete transients when activating cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Delete transients when cache is enabled
+
 ## 2.7.0
 
 - Preserve key TTL when calling (in|de)crement methods

--- a/includes/class-plugin.php
+++ b/includes/class-plugin.php
@@ -1210,10 +1210,10 @@ HTML;
      * Delete all transients if the cache was enabled successfully.
      * Callback for `redis_object_cache_enable` action.
      *
-     * @param bool $result
+     * @param bool $should_delete
      * @return void
      */
-    public function maybe_delete_transients( $result ) {
+    public function maybe_delete_transients( $should_delete ) {
         global $wpdb;
 
         if ( ! $result ) {

--- a/includes/class-plugin.php
+++ b/includes/class-plugin.php
@@ -1207,7 +1207,8 @@ HTML;
     }
 
     /**
-     * Registers all hooks associated with the shutdown hook
+     * Delete all transients if the cache was enabled successfully.
+     * Callback for `redis_object_cache_enable` action.
      *
      * @param bool $result
      * @return void
@@ -1215,7 +1216,9 @@ HTML;
     public function maybe_delete_transients( $result ) {
         global $wpdb;
 
-        if ( ! $result ) { return; }
+        if ( ! $result ) {
+            return;
+        }
 
         $wpdb->query( $wpdb->prepare(
             "DELETE FROM {$wpdb->options} WHERE option_name LIKE %s OR option_name LIKE %s",

--- a/includes/class-plugin.php
+++ b/includes/class-plugin.php
@@ -119,6 +119,8 @@ class Plugin {
 
         add_action( 'wp_head', [ $this, 'register_shutdown_hooks' ] );
 
+        add_action( 'redis_object_cache_enable', [ $this, 'maybe_delete_transients' ] );
+
         add_filter( 'qm/collectors', [ $this, 'register_qm_collector' ], 25 );
         add_filter( 'qm/outputter/html', [ $this, 'register_qm_output' ] );
 
@@ -1201,6 +1203,30 @@ HTML;
     public function register_shutdown_hooks() {
         if ( ! defined( 'WP_REDIS_DISABLE_COMMENT' ) || ! WP_REDIS_DISABLE_COMMENT ) {
             add_action( 'shutdown', [ $this, 'maybe_print_comment' ], 0 );
+        }
+    }
+
+    /**
+     * Registers all hooks associated with the shutdown hook
+     *
+     * @param bool $result
+     * @return void
+     */
+    public function maybe_delete_transients( $result ) {
+        global $wpdb;
+
+        if ( ! $result ) { return; }
+
+        $wpdb->query( $wpdb->prepare(
+            "DELETE FROM {$wpdb->options} WHERE option_name LIKE %s OR option_name LIKE %s",
+            '_transient_%',
+            '_site_transient_%'
+        ) );
+
+        if ( is_multisite() ) {
+            $wpdb->query( $wpdb->prepare(
+                "DELETE FROM {$wpdb->sitemeta} WHERE meta_key LIKE %s", '_site_transient_%'
+            ) );
         }
     }
 

--- a/includes/cli/class-commands.php
+++ b/includes/cli/class-commands.php
@@ -77,6 +77,14 @@ class Commands extends WP_CLI_Command {
                 FS_CHMOD_FILE
             );
 
+            /**
+             * Fires on cache enable event
+             *
+             * @since 1.3.5
+             * @param bool $result Whether the filesystem event (copy of the `object-cache.php` file) was successful.
+             */
+            do_action( 'redis_object_cache_enable', $result );
+
             if ( $copy ) {
                 WP_CLI::success( __( 'Object cache enabled.', 'redis-cache' ) );
             } else {

--- a/includes/cli/class-commands.php
+++ b/includes/cli/class-commands.php
@@ -83,7 +83,7 @@ class Commands extends WP_CLI_Command {
              * @since 1.3.5
              * @param bool $result Whether the filesystem event (copy of the `object-cache.php` file) was successful.
              */
-            do_action( 'redis_object_cache_enable', $result );
+            do_action( 'redis_object_cache_enable', $copy );
 
             if ( $copy ) {
                 WP_CLI::success( __( 'Object cache enabled.', 'redis-cache' ) );


### PR DESCRIPTION
This should avoid stale WooCommerce data.