### PR TITLE
Fix - Correct ABSPATH constant check

### DIFF
--- a/includes/class-autoloader.php
+++ b/includes/class-autoloader.php
@@ -7,7 +7,7 @@
 
 namespace Rhubarb\RedisCache;
 
-defined( '\\ABSPATH' ) || exit;
+defined( 'ABSPATH' ) || exit;
 
 /**
  * Autoloader class

--- a/includes/class-metrics.php
+++ b/includes/class-metrics.php
@@ -9,7 +9,7 @@ namespace Rhubarb\RedisCache;
 
 use Exception;
 
-defined( '\\ABSPATH' ) || exit;
+defined( 'ABSPATH' ) || exit;
 
 /**
  * Metrics collection class

--- a/includes/class-plugin.php
+++ b/includes/class-plugin.php
@@ -10,7 +10,7 @@ namespace Rhubarb\RedisCache;
 use WP_Error;
 use Exception;
 
-defined( '\\ABSPATH' ) || exit;
+defined( 'ABSPATH' ) || exit;
 
 /**
  * Main plugin class definition

--- a/includes/class-predis.php
+++ b/includes/class-predis.php
@@ -9,7 +9,7 @@ namespace Rhubarb\RedisCache;
 
 use Exception;
 
-defined( '\\ABSPATH' ) || exit;
+defined( 'ABSPATH' ) || exit;
 
 class Predis {
     /**

--- a/includes/class-qm-collector.php
+++ b/includes/class-qm-collector.php
@@ -11,7 +11,7 @@ use QM_Data;
 use QM_Data_Cache;
 use QM_Collector as QM_BaseCollector;
 
-defined( '\\ABSPATH' ) || exit;
+defined( 'ABSPATH' ) || exit;
 
 /**
  * Query Monitor data collector class definition

--- a/includes/class-qm-output.php
+++ b/includes/class-qm-output.php
@@ -9,7 +9,7 @@ namespace Rhubarb\RedisCache;
 
 use QM_Output_Html;
 
-defined( '\\ABSPATH' ) || exit;
+defined( 'ABSPATH' ) || exit;
 
 /**
  * Query Monitor output logic class definition

--- a/includes/class-ui.php
+++ b/includes/class-ui.php
@@ -7,7 +7,7 @@
 
 namespace Rhubarb\RedisCache;
 
-defined( '\\ABSPATH' ) || exit;
+defined( 'ABSPATH' ) || exit;
 
 /**
  * UI class definition

--- a/includes/cli/class-commands.php
+++ b/includes/cli/class-commands.php
@@ -14,7 +14,7 @@ use Exception;
 use Rhubarb\RedisCache\Plugin;
 use Rhubarb\RedisCache\Predis;
 
-defined( '\\ABSPATH' ) || exit;
+defined( 'ABSPATH' ) || exit;
 
 /**
  * Enables, disabled and checks the status of the object cache.

--- a/includes/diagnostics.php
+++ b/includes/diagnostics.php
@@ -5,7 +5,7 @@
  * @package Rhubarb\RedisCache
  */
 
-defined( '\\ABSPATH' ) || exit;
+defined( 'ABSPATH' ) || exit;
 
 global $wp_object_cache;
 

--- a/includes/object-cache.php
+++ b/includes/object-cache.php
@@ -13,7 +13,7 @@
  * @package Rhubarb\RedisCache
  */
 
-defined( '\\ABSPATH' ) || exit;
+defined( 'ABSPATH' ) || exit;
 
 // phpcs:disable Generic.WhiteSpace.ScopeIndent.IncorrectExact, Generic.WhiteSpace.ScopeIndent.Incorrect
 if ( ! defined( 'WP_REDIS_DISABLED' ) || ! WP_REDIS_DISABLED ) :

--- a/includes/ui/class-tab.php
+++ b/includes/ui/class-tab.php
@@ -9,7 +9,7 @@ namespace Rhubarb\RedisCache\UI;
 
 use Rhubarb\RedisCache\Plugin;
 
-defined( '\\ABSPATH' ) || exit;
+defined( 'ABSPATH' ) || exit;
 
 /**
  * Tab class definition

--- a/includes/ui/query-monitor.php
+++ b/includes/ui/query-monitor.php
@@ -5,7 +5,7 @@
  * @package Rhubarb\RedisCache
  */
 
-defined( '\\ABSPATH' ) || exit;
+defined( 'ABSPATH' ) || exit;
 
 /**
  * @var \Rhubarb\RedisCache\QM_Output $this

--- a/includes/ui/settings.php
+++ b/includes/ui/settings.php
@@ -10,7 +10,7 @@ namespace Rhubarb\RedisCache\UI;
 use Rhubarb\RedisCache\UI;
 use Rhubarb\RedisCache\Plugin;
 
-defined( '\\ABSPATH' ) || exit;
+defined( 'ABSPATH' ) || exit;
 
 ?>
 <div id="rediscache" class="wrap">

--- a/includes/ui/tabs/diagnostics.php
+++ b/includes/ui/tabs/diagnostics.php
@@ -5,7 +5,7 @@
  * @package Rhubarb\RedisCache
  */
 
-defined( '\\ABSPATH' ) || exit;
+defined( 'ABSPATH' ) || exit;
 
 ?>
 

--- a/includes/ui/tabs/metrics.php
+++ b/includes/ui/tabs/metrics.php
@@ -5,7 +5,7 @@
  * @package Rhubarb\RedisCache
  */
 
-defined( '\\ABSPATH' ) || exit;
+defined( 'ABSPATH' ) || exit;
 
 ?>
 

--- a/includes/ui/tabs/overview.php
+++ b/includes/ui/tabs/overview.php
@@ -5,7 +5,7 @@
  * @package Rhubarb\RedisCache
  */
 
-defined( '\\ABSPATH' ) || exit;
+defined( 'ABSPATH' ) || exit;
 
 /** @var \Rhubarb\RedisCache\Plugin $roc */
 $status = $roc->get_redis_status();

--- a/includes/ui/widget.php
+++ b/includes/ui/widget.php
@@ -5,7 +5,7 @@
  * @package Rhubarb\RedisCache
  */
 
-defined( '\\ABSPATH' ) || exit;
+defined( 'ABSPATH' ) || exit;
 
 /** @var \Rhubarb\RedisCache\Plugin $this */
 


### PR DESCRIPTION
This PR fixes the `ABSPATH` constant validation. The previous `\\ABSPATH` check was invalid and caused scripts to exit. It now uses the correct `ABSPATH` check, following the standard WordPress practice for secure file access.