### PR TITLE
Fix Predis Sentinel authentication when Sentinel requires password

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@
 
 - Delete transients when cache is enabled
 
+# 2.7.1
+
+- Support password configuration for Sentinel connections when using Predis (from @bsabalaskey)
+- Configuration uses `WP_REDIS_SENTINEL_PASSWORD` constant
+
 ## 2.7.0
 
 - Preserve key TTL when calling (in|de)crement methods

--- a/README.md
+++ b/README.md
@@ -47,24 +47,25 @@ The Redis Object Cache plugin comes with vast set of configuration options. If y
 <details>
 <summary>Advanced configuration options</summary>
 
-| Configuration constant               | Default     | Description                                   |
-| ------------------------------------ | ----------- | --------------------------------------------- |
-| `WP_CACHE_KEY_SALT`                  |             | Deprecated. Replaced by `WP_REDIS_PREFIX` |
-| `WP_REDIS_FLUSH_TIMEOUT`             | `5`         | Experimental. The timeout in seconds when flushing |
-| `WP_REDIS_RETRY_INTERVAL`            |             | The number of milliseconds between retries (PhpRedis only) |
-| `WP_REDIS_GLOBAL_GROUPS`             | `[]`        | Additional groups that are considered global on multisite networks |
-| `WP_REDIS_METRICS_MAX_TIME`          | `3600`      | The maximum number of seconds metrics should be stored |
-| `WP_REDIS_IGBINARY`                  | `false`     | Whether to use the igbinary PHP extension for serialization |
-| `WP_REDIS_DISABLED`                  | `false`     | Emergency switch to bypass the object cache without deleting the drop-in |
-| `WP_REDIS_DISABLE_ADMINBAR`          | `false`     | Disables admin bar display |
-| `WP_REDIS_DISABLE_METRICS`           | `false`     | Disables metrics collection and display |
-| `WP_REDIS_DISABLE_DROPIN_CHECK`      | `false`     | Disables the extended drop-in write test |
-| `WP_REDIS_DISABLE_DROPIN_AUTOUPDATE` | `false`     | Disables the drop-in auto-update |
-| `WP_REDIS_DISABLE_GROUP_FLUSH`       | `false`     | Disables group flushing with Lua script and uses `flushdb` call instead |
-| `WP_REDIS_DISABLE_BANNERS`           | `false`     | Disables promotional banners and notices |
-| `WP_REDIS_DISABLE_COMMENT`           | `false`     | Disables HTML source comment |
-| `WP_REDIS_SSL_CONTEXT`               | `[]`        | TLS connection options for `tls` or `rediss` scheme |
-| `WP_REDIS_MANAGER_CAPABILITY`        |             | The capability a user must have to manage the plugin |
+| Configuration constant               | Default     | Description                                                                             |
+|--------------------------------------| ----------- |-----------------------------------------------------------------------------------------|
+| `WP_CACHE_KEY_SALT`                  |             | Deprecated. Replaced by `WP_REDIS_PREFIX`                                               |
+| `WP_REDIS_FLUSH_TIMEOUT`             | `5`         | Experimental. The timeout in seconds when flushing                                      |
+| `WP_REDIS_RETRY_INTERVAL`            |             | The number of milliseconds between retries (PhpRedis only)                              |
+| `WP_REDIS_GLOBAL_GROUPS`             | `[]`        | Additional groups that are considered global on multisite networks                      |
+| `WP_REDIS_METRICS_MAX_TIME`          | `3600`      | The maximum number of seconds metrics should be stored                                  |
+| `WP_REDIS_IGBINARY`                  | `false`     | Whether to use the igbinary PHP extension for serialization                             |
+| `WP_REDIS_DISABLED`                  | `false`     | Emergency switch to bypass the object cache without deleting the drop-in                |
+| `WP_REDIS_DISABLE_ADMINBAR`          | `false`     | Disables admin bar display                                                              |
+| `WP_REDIS_DISABLE_METRICS`           | `false`     | Disables metrics collection and display                                                 |
+| `WP_REDIS_DISABLE_DROPIN_CHECK`      | `false`     | Disables the extended drop-in write test                                                |
+| `WP_REDIS_DISABLE_DROPIN_AUTOUPDATE` | `false`     | Disables the drop-in auto-update                                                        |
+| `WP_REDIS_DISABLE_GROUP_FLUSH`       | `false`     | Disables group flushing with Lua script and uses `flushdb` call instead                 |
+| `WP_REDIS_DISABLE_BANNERS`           | `false`     | Disables promotional banners and notices                                                |
+| `WP_REDIS_DISABLE_COMMENT`           | `false`     | Disables HTML source comment                                                            |
+| `WP_REDIS_SSL_CONTEXT`               | `[]`        | TLS connection options for `tls` or `rediss` scheme                                     |
+| `WP_REDIS_MANAGER_CAPABILITY`        |             | The capability a user must have to manage the plugin                                    |
+| `WP_REDIS_SENTINEL_PASSWORD`         |             | The password of the Sentinel server, supports Redis ACLs arrays: `['user', 'password']` |
 
 </details>
 
@@ -195,6 +196,8 @@ define( 'WP_REDIS_SERVERS', [
     'tcp://127.0.0.2:5381',
     'tcp://127.0.0.3:5382',
 ] );
+
+define( 'WP_REDIS_SENTINEL_PASSWORD', 'my-password' );
 ```
 
 </details>

--- a/includes/class-predis.php
+++ b/includes/class-predis.php
@@ -53,6 +53,7 @@ class Predis {
             'port',
             'path',
             'password',
+            'sentinel_password',
             'database',
             'timeout',
             'read_timeout',
@@ -68,6 +69,9 @@ class Predis {
 
         if ( isset( $parameters['password'] ) && $parameters['password'] === '' ) {
             unset( $parameters['password'] );
+        }
+        if ( isset( $parameters['sentinel_password'] ) && $parameters['sentinel_password'] === '' ) {
+            unset( $parameters['sentinel_password'] );
         }
 
         if ( defined( 'WP_REDIS_SHARDS' ) ) {
@@ -112,10 +116,10 @@ class Predis {
                 }
 
                 // Add support for password in Sentinel parameters when using Predis
-                if ( $constant == 'WP_REDIS_SERVERS' && defined( 'WP_REDIS_SENTINEL' ) && isset( $parameters['password'] ) ) {
+                if ( $constant == 'WP_REDIS_SERVERS' && defined( 'WP_REDIS_SENTINEL' ) && isset( $parameters['sentinel_password'] ) ) {
                     foreach( $servers as $index => $server ) {
                         // skip any connect string that already has a password, e.g. tcp://1.2.3.4:26379?password=abc123
-                        if ( str_contains( $server, 'password=' ) ) {
+                        if ( strpos( $server, 'password=' ) !== false ) {
                             continue;
                         }
                         // convert server string to array of components to add password
@@ -128,11 +132,11 @@ class Predis {
                             'host'   => $urlParts['host'] ?? 'localhost',
                             'port'   => $urlParts['port'] ?? 26379,
                         ];
-                        if ( is_array( $parameters['password'] ) ) {
-                            $entry['username'] = WP_REDIS_PASSWORD[0];
-                            $entry['password'] = WP_REDIS_PASSWORD[1];
+                        if ( is_array( $parameters['sentinel_password'] ) ) {
+                            $entry['username'] = WP_REDIS_SENTINEL_PASSWORD[0];
+                            $entry['password'] = WP_REDIS_SENTINEL_PASSWORD[1];
                         } else {
-                            $entry['password'] = WP_REDIS_PASSWORD;
+                            $entry['password'] = WP_REDIS_SENTINEL_PASSWORD;
                         }
                         $servers[$index] = $entry; // replace server string with array of connection parameters
                     }

--- a/includes/class-predis.php
+++ b/includes/class-predis.php
@@ -110,6 +110,37 @@ class Predis {
                         $options['parameters']['password'] = WP_REDIS_PASSWORD;
                     }
                 }
+
+                // Add support for password in Sentinel parameters when using Predis
+                if ( $constant == 'WP_REDIS_SERVERS' && defined( 'WP_REDIS_SENTINEL' ) && isset( $parameters['password'] ) ) {
+                    foreach( $servers as $index => $server ) {
+                        // skip any connect string that already has a password, e.g. tcp://1.2.3.4:26379?password=abc123
+                        if ( str_contains( $server, 'password=' ) ) {
+                            continue;
+                        }
+                        // convert server string to array of components to add password
+                        $urlParts = parse_url( $server );
+                        if ( !$urlParts ) {
+                            continue; // can't parse this server string, skip it
+                        }
+                        $entry  = [
+                            'scheme' => $urlParts['scheme'] ?? 'tcp',
+                            'host'   => $urlParts['host'] ?? 'localhost',
+                            'port'   => $urlParts['port'] ?? 26379,
+                        ];
+                        if ( is_array( $parameters['password'] ) ) {
+                            $entry['username'] = WP_REDIS_PASSWORD[0];
+                            $entry['password'] = WP_REDIS_PASSWORD[1];
+                        } else {
+                            $entry['password'] = WP_REDIS_PASSWORD;
+                        }
+                        $servers[$index] = $entry; // replace server string with array of connection parameters
+                    }
+
+                    if ( ! empty( $parameters['timeout'] ) ) {
+                        $options['parameters']['timeout'] = $parameters['timeout'];
+                    }
+                }
             }
         }
 

--- a/includes/object-cache.php
+++ b/includes/object-cache.php
@@ -907,23 +907,25 @@ class WP_Object_Cache {
                         if ( str_contains( $server, 'password=' ) ) {
                             continue;
                         }
-                        // convert server string to array of components to add password
-                        $urlParts = parse_url( $server );
-                        if ( !$urlParts ) {
-                            continue; // can't parse this server string, skip it
+
+                        if ( ! $urlParts = parse_url( $server ) ) {
+                            continue;
                         }
+
                         $entry  = [
                             'scheme' => $urlParts['scheme'] ?? 'tcp',
                             'host'   => $urlParts['host'] ?? 'localhost',
                             'port'   => $urlParts['port'] ?? 26379,
                         ];
+
                         if ( is_array( $parameters['password'] ) ) {
                             $entry['username'] = WP_REDIS_PASSWORD[0];
                             $entry['password'] = WP_REDIS_PASSWORD[1];
                         } else {
                             $entry['password'] = WP_REDIS_PASSWORD;
                         }
-                        $servers[$index] = $entry; // replace server string with array of connection parameters
+
+                        $servers[$index] = $entry;
                     }
 
                     if ( ! empty( $parameters['timeout'] ) ) {

--- a/includes/object-cache.php
+++ b/includes/object-cache.php
@@ -636,6 +636,7 @@ class WP_Object_Cache {
             'port',
             'path',
             'password',
+            'sentinel_password',
             'database',
             'timeout',
             'read_timeout',
@@ -652,6 +653,9 @@ class WP_Object_Cache {
 
         if ( isset( $parameters[ 'password' ] ) && $parameters[ 'password' ] === '' ) {
             unset( $parameters[ 'password' ] );
+        }
+        if ( isset( $parameters['sentinel_password'] ) && $parameters['sentinel_password'] === '' ) {
+            unset( $parameters['sentinel_password'] );
         }
 
         $this->diagnostics[ 'timeout' ] = $parameters[ 'timeout' ];
@@ -901,10 +905,10 @@ class WP_Object_Cache {
                 }
 
                 // Add support for password in Sentinel parameters when using Predis
-                if ( $constant == 'WP_REDIS_SERVERS' && defined( 'WP_REDIS_SENTINEL' ) && isset( $parameters['password'] ) ) {
+                if ( $constant == 'WP_REDIS_SERVERS' && defined( 'WP_REDIS_SENTINEL' ) && isset( $parameters['sentinel_password'] ) ) {
                     foreach( $servers as $index => $server ) {
                         // skip any connect string that already has a password, e.g. tcp://1.2.3.4:26379?password=abc123
-                        if ( str_contains( $server, 'password=' ) ) {
+                        if ( strpos( $server, 'password=' ) !== false ) {
                             continue;
                         }
                         // convert server string to array of components to add password
@@ -917,11 +921,11 @@ class WP_Object_Cache {
                             'host'   => $urlParts['host'] ?? 'localhost',
                             'port'   => $urlParts['port'] ?? 26379,
                         ];
-                        if ( is_array( $parameters['password'] ) ) {
-                            $entry['username'] = WP_REDIS_PASSWORD[0];
-                            $entry['password'] = WP_REDIS_PASSWORD[1];
+                        if ( is_array( $parameters['sentinel_password'] ) ) {
+                            $entry['username'] = WP_REDIS_SENTINEL_PASSWORD[0];
+                            $entry['password'] = WP_REDIS_SENTINEL_PASSWORD[1];
                         } else {
-                            $entry['password'] = WP_REDIS_PASSWORD;
+                            $entry['password'] = WP_REDIS_SENTINEL_PASSWORD;
                         }
                         $servers[$index] = $entry; // replace server string with array of connection parameters
                     }

--- a/includes/object-cache.php
+++ b/includes/object-cache.php
@@ -899,6 +899,37 @@ class WP_Object_Cache {
                         $options['parameters']['password'] = WP_REDIS_PASSWORD;
                     }
                 }
+
+                // Add support for password in Sentinel parameters when using Predis
+                if ( $constant == 'WP_REDIS_SERVERS' && defined( 'WP_REDIS_SENTINEL' ) && isset( $parameters['password'] ) ) {
+                    foreach( $servers as $index => $server ) {
+                        // skip any connect string that already has a password, e.g. tcp://1.2.3.4:26379?password=abc123
+                        if ( str_contains( $server, 'password=' ) ) {
+                            continue;
+                        }
+                        // convert server string to array of components to add password
+                        $urlParts = parse_url( $server );
+                        if ( !$urlParts ) {
+                            continue; // can't parse this server string, skip it
+                        }
+                        $entry  = [
+                            'scheme' => $urlParts['scheme'] ?? 'tcp',
+                            'host'   => $urlParts['host'] ?? 'localhost',
+                            'port'   => $urlParts['port'] ?? 26379,
+                        ];
+                        if ( is_array( $parameters['password'] ) ) {
+                            $entry['username'] = WP_REDIS_PASSWORD[0];
+                            $entry['password'] = WP_REDIS_PASSWORD[1];
+                        } else {
+                            $entry['password'] = WP_REDIS_PASSWORD;
+                        }
+                        $servers[$index] = $entry; // replace server string with array of connection parameters
+                    }
+
+                    if ( ! empty( $parameters['timeout'] ) ) {
+                        $options['parameters']['timeout'] = $parameters['timeout'];
+                    }
+                }
             }
         }
 

--- a/redis-cache.php
+++ b/redis-cache.php
@@ -3,7 +3,7 @@
  * Plugin Name: Redis Object Cache
  * Plugin URI: https://wordpress.org/plugins/redis-cache/
  * Description: A persistent object cache backend powered by Redis. Supports Predis, PhpRedis, Relay, replication, sentinels, clustering and WP-CLI.
- * Version: 2.7.0
+ * Version: 2.7.1
  * Text Domain: redis-cache
  * Domain Path: /languages
  * Network: true


### PR DESCRIPTION
Problem: WP_REDIS_PASSWORD is applied to Redis node parameters but not Sentinel-specific parameters in Predis Sentinel mode.

Symptom: admin health check shows Redis as unreachable unless each Sentinel URI includes ?password=whatever

Fix: propagate Redis password and optional username into $servers when WP_REDIS_SENTINEL is defined.

Why it matters: avoids forcing credentials into each Sentinel URI and makes authenticated Sentinel setups work consistently and easier.

### Reproduce the Problem and Showing the Fix

1. Configure authenticated Redis Sentinel
2. Set WP_REDIS_CLIENT = 'predis'. 
3. Set WP_REDIS_SENTINEL and WP_REDIS_SERVERS (like 'tcp://1.2.3.4:26379')
4. Set WP_REDIS_PASSWORD
5. Observe NOAUTH Authentication required; plugin reports Redis unreachable and not possible to enable object caching
6. Apply changes from this code
7. Connection succeeds and you can enable object cache

### Tested With

- Redis Sentinel 3-node setup (separate from WordPress servers), Redis v8.6.1
- Redis and Sentinel password set to identical values, with default user (no ACL)
- Predis client v2.4.0
- Authenticated Sentinel and Redis using same password (they must be identical)
- Confirmed admin check and runtime connection both work after patch 
- PHP Version: 8.2.30 with NGINX using PHP FPM
- WordPress v6.9.1
- Default Redis port of 6379 and Sentinel port 26379