### PR TITLE
remove unnecessary group_types array and associated methods.

### DIFF
--- a/includes/diagnostics.php
+++ b/includes/diagnostics.php
@@ -121,37 +121,43 @@ if ( isset( $info['WP_REDIS_SERVERS'] ) ) {
 }
 
 if ( $dropin && ! $disabled ) {
+    // Normalize group arrays to a plain list of names regardless of whether stored as
+    // an associative set (group_name => true) or a legacy indexed list.
+    $normalize_group_names = static function ( $groups ) {
+        $groups = (array) $groups;
+        if ( empty( $groups ) ) {
+            return array();
+        }
+        $keys = array_keys( $groups );
+        return ( $keys === range( 0, count( $groups ) - 1 ) ) ? array_values( $groups ) : $keys;
+    };
+
     $info['Global Groups'] = wp_json_encode(
-        array_keys( (array) ( $wp_object_cache->global_groups ?? [] ) ),
+        $normalize_group_names( $wp_object_cache->global_groups ?? [] ),
         JSON_PRETTY_PRINT
     );
 
     $info['Ignored Groups'] = wp_json_encode(
-        array_keys( (array) ( $wp_object_cache->ignored_groups ?? [] ) ),
+        $normalize_group_names( $wp_object_cache->ignored_groups ?? [] ),
         JSON_PRETTY_PRINT
     );
 
     $info['Unflushable Groups'] = wp_json_encode(
-        array_keys( (array) ( $wp_object_cache->unflushable_groups ?? [] ) ),
+        $normalize_group_names( $wp_object_cache->unflushable_groups ?? [] ),
         JSON_PRETTY_PRINT
     );
 
-    // Compute group types on-the-fly from the group arrays
+    // Compute group types on-the-fly using the same precedence as the removed cache_group_types():
+    // later entries overwrite earlier ones, so ignored > unflushable > global.
     $group_types = [];
-    foreach ( (array) $wp_object_cache->global_groups as $group => $_unused ) {
-        if ( ! isset( $group_types[ $group ] ) ) {
-            $group_types[ $group ] = 'global';
-        }
+    foreach ( $normalize_group_names( $wp_object_cache->global_groups ?? [] ) as $group ) {
+        $group_types[ $group ] = 'global';
     }
-    foreach ( (array) $wp_object_cache->ignored_groups as $group => $_unused ) {
-        if ( ! isset( $group_types[ $group ] ) ) {
-            $group_types[ $group ] = 'ignored';
-        }
+    foreach ( $normalize_group_names( $wp_object_cache->unflushable_groups ?? [] ) as $group ) {
+        $group_types[ $group ] = 'unflushable';
     }
-    foreach ( (array) $wp_object_cache->unflushable_groups as $group => $_unused ) {
-        if ( ! isset( $group_types[ $group ] ) ) {
-            $group_types[ $group ] = 'unflushable';
-        }
+    foreach ( $normalize_group_names( $wp_object_cache->ignored_groups ?? [] ) as $group ) {
+        $group_types[ $group ] = 'ignored';
     }
 
     $info['Groups Types'] = wp_json_encode(

--- a/includes/diagnostics.php
+++ b/includes/diagnostics.php
@@ -122,22 +122,40 @@ if ( isset( $info['WP_REDIS_SERVERS'] ) ) {
 
 if ( $dropin && ! $disabled ) {
     $info['Global Groups'] = wp_json_encode(
-        array_values( $wp_object_cache->global_groups ?? [] ),
+        array_keys( (array) ( $wp_object_cache->global_groups ?? [] ) ),
         JSON_PRETTY_PRINT
     );
 
     $info['Ignored Groups'] = wp_json_encode(
-        array_values( $wp_object_cache->ignored_groups ?? [] ),
+        array_keys( (array) ( $wp_object_cache->ignored_groups ?? [] ) ),
         JSON_PRETTY_PRINT
     );
 
     $info['Unflushable Groups'] = wp_json_encode(
-        array_values( $wp_object_cache->unflushable_groups ?? [] ),
+        array_keys( (array) ( $wp_object_cache->unflushable_groups ?? [] ) ),
         JSON_PRETTY_PRINT
     );
 
+    // Compute group types on-the-fly from the group arrays
+    $group_types = [];
+    foreach ( (array) $wp_object_cache->global_groups as $group => $_unused ) {
+        if ( ! isset( $group_types[ $group ] ) ) {
+            $group_types[ $group ] = 'global';
+        }
+    }
+    foreach ( (array) $wp_object_cache->ignored_groups as $group => $_unused ) {
+        if ( ! isset( $group_types[ $group ] ) ) {
+            $group_types[ $group ] = 'ignored';
+        }
+    }
+    foreach ( (array) $wp_object_cache->unflushable_groups as $group => $_unused ) {
+        if ( ! isset( $group_types[ $group ] ) ) {
+            $group_types[ $group ] = 'unflushable';
+        }
+    }
+
     $info['Groups Types'] = wp_json_encode(
-        $wp_object_cache->group_type ?? null,
+        $group_types ?: null,
         JSON_PRETTY_PRINT
     );
 }

--- a/includes/object-cache.php
+++ b/includes/object-cache.php
@@ -415,21 +415,21 @@ class WP_Object_Cache {
     /**
      * List of global groups.
      *
-     * @var array<string>
+     * @var array<string, bool>
      */
     public $global_groups = [];
 
     /**
      * List of groups that will not be flushed.
      *
-     * @var array
+     * @var array<string, bool>
      */
     public $unflushable_groups = [];
 
     /**
      * List of groups not saved to Redis.
      *
-     * @var array
+     * @var array<string, bool>
      */
     public $ignored_groups = [];
 
@@ -2570,23 +2570,28 @@ LUA;
     }
 
     /**
-     * Checks if the given group is part the global group array
+     * Checks if the given group is part the global group array.
+     * Ignored groups take precedence over global; unflushable also takes precedence over global.
      *
      * @param string $group  Name of the group to check, pre-sanitized.
      * @return bool
      */
     protected function is_global_group( $group ) {
-        return isset( $this->global_groups[ $group ] );
+        return isset( $this->global_groups[ $group ] )
+            && ! isset( $this->ignored_groups[ $group ] )
+            && ! isset( $this->unflushable_groups[ $group ] );
     }
 
     /**
-     * Checks if the given group is part the unflushable group array
+     * Checks if the given group is part the unflushable group array.
+     * Ignored groups take precedence over unflushable.
      *
      * @param string $group  Name of the group to check, pre-sanitized.
      * @return bool
      */
     protected function is_unflushable_group( $group ) {
-        return isset( $this->unflushable_groups[ $group ] );
+        return isset( $this->unflushable_groups[ $group ] )
+            && ! isset( $this->ignored_groups[ $group ] );
     }
 
     /**

--- a/includes/object-cache.php
+++ b/includes/object-cache.php
@@ -434,13 +434,6 @@ class WP_Object_Cache {
     public $ignored_groups = [];
 
     /**
-     * List of groups and their types.
-     *
-     * @var array
-     */
-    public $group_type = [];
-
-    /**
      * Prefix used for global groups.
      *
      * @var string
@@ -2476,6 +2469,20 @@ LUA;
     public function info() {
         $total = $this->cache_hits + $this->cache_misses;
 
+        $normalize_group_list = function ( $groups ) {
+            if ( ! is_array( $groups ) || empty( $groups ) ) {
+                return [];
+            }
+
+            $keys = array_keys( $groups );
+
+            if ( $keys === range( 0, count( $groups ) - 1 ) ) {
+                return array_values( $groups );
+            }
+
+            return $keys;
+        };
+
         $bytes = array_map(
             function ( $keys ) {
                 // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.serialize_serialize
@@ -2492,9 +2499,9 @@ LUA;
             'time' => $this->cache_time,
             'calls' => $this->cache_calls,
             'groups' => (object) [
-                'global' => $this->global_groups,
-                'non_persistent' => $this->ignored_groups,
-                'unflushable' => $this->unflushable_groups,
+                'global' => $normalize_group_list( $this->global_groups ),
+                'non_persistent' => $normalize_group_list( $this->ignored_groups ),
+                'unflushable' => $normalize_group_list( $this->unflushable_groups ),
             ],
             'errors' => empty( $this->errors ) ? null : $this->errors,
             'meta' => [
@@ -2659,7 +2666,7 @@ LUA;
      * @param array $groups List of groups that are global.
      */
     public function add_global_groups( $groups ) {
-        $groups = (array) $groups;
+        $groups = array_map( array( $this, 'sanitize_key_part' ), (array) $groups );
 
         if ( $this->redis_status() ) {
             $this->global_groups = array_merge( $this->global_groups, array_fill_keys( $groups, true ) );
@@ -2682,6 +2689,9 @@ LUA;
          */
         $groups = apply_filters( 'redis_cache_add_non_persistent_groups', (array) $groups );
 
+        // Sanitize group names to keep behavior consistent with the rest of the cache key path.
+        $groups = array_map( array( $this, 'sanitize_key_part' ), $groups );
+
         $this->ignored_groups = array_merge( $this->ignored_groups, array_fill_keys( $groups, true ) );
     }
 
@@ -2691,7 +2701,7 @@ LUA;
      * @param array $groups List of groups that are unflushable.
      */
     public function add_unflushable_groups( $groups ) {
-        $groups = (array) $groups;
+        $groups = array_map( array( $this, 'sanitize_key_part' ), (array) $groups );
 
         $this->unflushable_groups = array_merge( $this->unflushable_groups, array_fill_keys( $groups, true ) );
     }
@@ -2857,7 +2867,13 @@ LUA;
         $this->redis_connected = false;
 
         // When Redis is unavailable, fall back to the internal cache by forcing all groups to be "no redis" groups.
-        $this->add_non_persistent_groups( array_keys( $this->global_groups ) );
+        if ( is_array( $this->global_groups ) && $this->global_groups ) {
+            $keys        = array_keys( $this->global_groups );
+            $is_list     = $keys === range( 0, count( $this->global_groups ) - 1 );
+            $group_names = $is_list ? $this->global_groups : $keys;
+
+            $this->add_non_persistent_groups( $group_names );
+        }
 
         error_log( $exception ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
 

--- a/includes/object-cache.php
+++ b/includes/object-cache.php
@@ -417,25 +417,7 @@ class WP_Object_Cache {
      *
      * @var array<string>
      */
-    public $global_groups = [
-        'blog-details',
-        'blog-id-cache',
-        'blog-lookup',
-        'global-posts',
-        'networks',
-        'rss',
-        'sites',
-        'site-details',
-        'site-lookup',
-        'site-options',
-        'site-transient',
-        'users',
-        'useremail',
-        'userlogins',
-        'usermeta',
-        'user_meta',
-        'userslugs',
-    ];
+    public $global_groups = [];
 
     /**
      * List of groups that will not be flushed.
@@ -511,20 +493,18 @@ class WP_Object_Cache {
         $this->fail_gracefully = $fail_gracefully;
 
         if ( defined( 'WP_REDIS_GLOBAL_GROUPS' ) && is_array( WP_REDIS_GLOBAL_GROUPS ) ) {
-            $this->global_groups = array_map( [ $this, 'sanitize_key_part' ], WP_REDIS_GLOBAL_GROUPS );
+            $this->global_groups = array_fill_keys( array_map( [ $this, 'sanitize_key_part' ], WP_REDIS_GLOBAL_GROUPS ), true );
         }
 
-        $this->global_groups[] = 'redis-cache';
+        $this->global_groups['redis-cache'] = true;
 
         if ( defined( 'WP_REDIS_IGNORED_GROUPS' ) && is_array( WP_REDIS_IGNORED_GROUPS ) ) {
-            $this->ignored_groups = array_map( [ $this, 'sanitize_key_part' ], WP_REDIS_IGNORED_GROUPS );
+            $this->ignored_groups = array_fill_keys( array_map( [ $this, 'sanitize_key_part' ], WP_REDIS_IGNORED_GROUPS ), true );
         }
 
         if ( defined( 'WP_REDIS_UNFLUSHABLE_GROUPS' ) && is_array( WP_REDIS_UNFLUSHABLE_GROUPS ) ) {
-            $this->unflushable_groups = array_map( [ $this, 'sanitize_key_part' ], WP_REDIS_UNFLUSHABLE_GROUPS );
+            $this->unflushable_groups = array_fill_keys( array_map( [ $this, 'sanitize_key_part' ], WP_REDIS_UNFLUSHABLE_GROUPS ), true );
         }
-
-        $this->cache_group_types();
 
         $this->use_igbinary = defined( 'WP_REDIS_IGBINARY' ) && WP_REDIS_IGBINARY && extension_loaded( 'igbinary' );
 
@@ -571,25 +551,6 @@ class WP_Object_Cache {
         if ( function_exists( 'is_multisite' ) ) {
             $this->global_prefix = is_multisite() ? '' : $table_prefix;
             $this->blog_prefix = is_multisite() ? $blog_id : $table_prefix;
-        }
-    }
-
-    /**
-     * Set group type array
-     *
-     * @return void
-     */
-    protected function cache_group_types() {
-        foreach ( $this->global_groups as $group ) {
-            $this->group_type[ $group ] = 'global';
-        }
-
-        foreach ( $this->unflushable_groups as $group ) {
-            $this->group_type[ $group ] = 'unflushable';
-        }
-
-        foreach ( $this->ignored_groups as $group ) {
-            $this->group_type[ $group ] = 'ignored';
         }
     }
 
@@ -1728,7 +1689,7 @@ class WP_Object_Cache {
             }
         }
 
-        if ( in_array( $san_group, $this->unflushable_groups ) ) {
+        if ( $this->is_unflushable_group( $san_group ) ) {
             return false;
         }
 
@@ -1857,7 +1818,7 @@ LUA;
                 function ( $group ) {
                     return ":{$group}:";
                 },
-                $this->unflushable_groups
+                array_keys( $this->unflushable_groups )
             );
 
             $script = <<<LUA
@@ -2598,7 +2559,7 @@ LUA;
      * @return bool
      */
     protected function is_ignored_group( $group ) {
-        return $this->is_group_of_type( $group, 'ignored' );
+        return isset( $this->ignored_groups[ $group ] );
     }
 
     /**
@@ -2608,7 +2569,7 @@ LUA;
      * @return bool
      */
     protected function is_global_group( $group ) {
-        return $this->is_group_of_type( $group, 'global' );
+        return isset( $this->global_groups[ $group ] );
     }
 
     /**
@@ -2618,19 +2579,7 @@ LUA;
      * @return bool
      */
     protected function is_unflushable_group( $group ) {
-        return $this->is_group_of_type( $group, 'unflushable' );
-    }
-
-    /**
-     * Checks the type of the given group
-     *
-     * @param string $group  Name of the group to check, pre-sanitized.
-     * @param string $type   Type of the group to check.
-     * @return bool
-     */
-    private function is_group_of_type( $group, $type ) {
-        return isset( $this->group_type[ $group ] )
-            && $this->group_type[ $group ] == $type;
+        return isset( $this->unflushable_groups[ $group ] );
     }
 
     /**
@@ -2713,12 +2662,10 @@ LUA;
         $groups = (array) $groups;
 
         if ( $this->redis_status() ) {
-            $this->global_groups = array_unique( array_merge( $this->global_groups, $groups ) );
+            $this->global_groups = array_merge( $this->global_groups, array_fill_keys( $groups, true ) );
         } else {
-            $this->ignored_groups = array_unique( array_merge( $this->ignored_groups, $groups ) );
+            $this->ignored_groups = array_merge( $this->ignored_groups, array_fill_keys( $groups, true ) );
         }
-
-        $this->cache_group_types();
     }
 
     /**
@@ -2735,8 +2682,7 @@ LUA;
          */
         $groups = apply_filters( 'redis_cache_add_non_persistent_groups', (array) $groups );
 
-        $this->ignored_groups = array_unique( array_merge( $this->ignored_groups, $groups ) );
-        $this->cache_group_types();
+        $this->ignored_groups = array_merge( $this->ignored_groups, array_fill_keys( $groups, true ) );
     }
 
     /**
@@ -2747,8 +2693,7 @@ LUA;
     public function add_unflushable_groups( $groups ) {
         $groups = (array) $groups;
 
-        $this->unflushable_groups = array_unique( array_merge( $this->unflushable_groups, $groups ) );
-        $this->cache_group_types();
+        $this->unflushable_groups = array_merge( $this->unflushable_groups, array_fill_keys( $groups, true ) );
     }
 
     /**
@@ -2912,7 +2857,7 @@ LUA;
         $this->redis_connected = false;
 
         // When Redis is unavailable, fall back to the internal cache by forcing all groups to be "no redis" groups.
-        $this->ignored_groups = array_unique( array_merge( $this->ignored_groups, $this->global_groups ) );
+        $this->add_non_persistent_groups( array_keys( $this->global_groups ) );
 
         error_log( $exception ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
 

--- a/tests/Feature/CacheTest.php
+++ b/tests/Feature/CacheTest.php
@@ -355,4 +355,43 @@ class CacheTest extends TestCase
 
         $this->assertSame($expected, $found);
     }
+
+    /**
+     * Test that group arrays maintain their expected shape and types.
+     * Verifies that groups are stored as associative sets (keys are group names, values are true).
+     */
+    public function testGroupArraysShape(): void
+    {
+        // Create a fresh cache instance to capture initial state
+        $cache = new \WP_Object_Cache();
+
+        // Verify that global_groups is an associative array with string keys and true values
+        $this->assertIsArray($cache->global_groups);
+        $this->assertNotEmpty($cache->global_groups);
+        foreach ($cache->global_groups as $group_name => $value) {
+            $this->assertIsString($group_name);
+            $this->assertTrue($value);
+        }
+
+        // Test add_global_groups adds groups correctly
+        $cache->add_global_groups(['custom_group']);
+        $this->assertArrayHasKey('custom_group', $cache->global_groups);
+        $this->assertTrue($cache->global_groups['custom_group']);
+
+        // Test add_non_persistent_groups
+        $cache->add_non_persistent_groups(['non_persistent_group']);
+        $this->assertArrayHasKey('non_persistent_group', $cache->ignored_groups);
+        $this->assertTrue($cache->ignored_groups['non_persistent_group']);
+
+        // Test add_unflushable_groups
+        $cache->add_unflushable_groups(['unflushable_group']);
+        $this->assertArrayHasKey('unflushable_group', $cache->unflushable_groups);
+        $this->assertTrue($cache->unflushable_groups['unflushable_group']);
+
+        // info()->groups should expose previous list format of group names.
+        $info = $cache->info();
+        $this->assertContains('custom_group', $info->groups->global);
+        $this->assertContains('non_persistent_group', $info->groups->non_persistent);
+        $this->assertContains('unflushable_group', $info->groups->unflushable);
+    }
 }

--- a/tests/Feature/CacheTest.php
+++ b/tests/Feature/CacheTest.php
@@ -373,25 +373,35 @@ class CacheTest extends TestCase
             $this->assertTrue($value);
         }
 
-        // Test add_global_groups adds groups correctly
-        $cache->add_global_groups(['custom_group']);
-        $this->assertArrayHasKey('custom_group', $cache->global_groups);
-        $this->assertTrue($cache->global_groups['custom_group']);
+        // Test add_global_groups: when Redis is connected the group lands in global_groups;
+        // when unavailable it falls back to ignored_groups.
+        $cache->add_global_groups( array( 'custom_group' ) );
+        if ( $cache->redis_status() ) {
+            $this->assertArrayHasKey( 'custom_group', $cache->global_groups );
+            $this->assertTrue( $cache->global_groups['custom_group'] );
+        } else {
+            $this->assertArrayHasKey( 'custom_group', $cache->ignored_groups );
+            $this->assertTrue( $cache->ignored_groups['custom_group'] );
+        }
 
         // Test add_non_persistent_groups
-        $cache->add_non_persistent_groups(['non_persistent_group']);
-        $this->assertArrayHasKey('non_persistent_group', $cache->ignored_groups);
-        $this->assertTrue($cache->ignored_groups['non_persistent_group']);
+        $cache->add_non_persistent_groups( array( 'non_persistent_group' ) );
+        $this->assertArrayHasKey( 'non_persistent_group', $cache->ignored_groups );
+        $this->assertTrue( $cache->ignored_groups['non_persistent_group'] );
 
         // Test add_unflushable_groups
-        $cache->add_unflushable_groups(['unflushable_group']);
-        $this->assertArrayHasKey('unflushable_group', $cache->unflushable_groups);
-        $this->assertTrue($cache->unflushable_groups['unflushable_group']);
+        $cache->add_unflushable_groups( array( 'unflushable_group' ) );
+        $this->assertArrayHasKey( 'unflushable_group', $cache->unflushable_groups );
+        $this->assertTrue( $cache->unflushable_groups['unflushable_group'] );
 
         // info()->groups should expose previous list format of group names.
         $info = $cache->info();
-        $this->assertContains('custom_group', $info->groups->global);
-        $this->assertContains('non_persistent_group', $info->groups->non_persistent);
-        $this->assertContains('unflushable_group', $info->groups->unflushable);
+        if ( $cache->redis_status() ) {
+            $this->assertContains( 'custom_group', $info->groups->global );
+        } else {
+            $this->assertContains( 'custom_group', $info->groups->non_persistent );
+        }
+        $this->assertContains( 'non_persistent_group', $info->groups->non_persistent );
+        $this->assertContains( 'unflushable_group', $info->groups->unflushable );
     }
 }


### PR DESCRIPTION
the performance optimizations introduced with the associative array in https://github.com/rhubarbgroup/redis-cache/pull/340 didnt actually require adding the group_types array and associated methods. Better to just convert global/ignored/unflushable_groups themselves to associative arrays and use isset on those directly.