### PR TITLE
fix(predis): set ['ssl'] for cluster + WP_REDIS_SSL_CONTEXT (#614)

### DIFF
--- a/includes/class-predis.php
+++ b/includes/class-predis.php
@@ -126,6 +126,9 @@ class Predis {
 
         if ( defined( 'WP_REDIS_SSL_CONTEXT' ) && ! empty( WP_REDIS_SSL_CONTEXT ) ) {
             $parameters['ssl'] = WP_REDIS_SSL_CONTEXT;
+            if ( defined( 'WP_REDIS_CLUSTER' ) ) {
+                $options['parameters']['ssl'] = WP_REDIS_SSL_CONTEXT;
+            }
         }
 
         $this->redis = new \Predis\Client( $servers ?: $parameters, $options );

--- a/includes/object-cache.php
+++ b/includes/object-cache.php
@@ -915,6 +915,9 @@ class WP_Object_Cache {
 
         if ( defined( 'WP_REDIS_SSL_CONTEXT' ) && ! empty( WP_REDIS_SSL_CONTEXT ) ) {
             $parameters['ssl'] = WP_REDIS_SSL_CONTEXT;
+            if ( defined( 'WP_REDIS_CLUSTER' ) ) {
+                $options['parameters']['ssl'] = WP_REDIS_SSL_CONTEXT;
+            }
         }
 
         $this->redis = new Predis\Client( $servers ?: $parameters, $options );


### PR DESCRIPTION
Fix for https://github.com/rhubarbgroup/redis-cache/issues/614