### PR TITLE
Rename WP_REDIS_DISABLE_CHARTS to WP_REDIS_LOAD_APEXCHARTS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Unreleased
 
 - Added `WP_REDIS_CHART_COLOR` constant
-- Added `WP_REDIS_DISABLE_CHARTS` constant
+- Added `WP_REDIS_LOAD_APEXCHARTS` constant
 - Upgrade ApexCharts to v4.7.0
 
 ## 2.8.0

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ The Redis Object Cache plugin comes with vast set of configuration options. If y
 | `WP_REDIS_DISABLE_GROUP_FLUSH`       | `false`     | Disables group flushing with Lua script and uses `flushdb` call instead |
 | `WP_REDIS_DISABLE_BANNERS`           | `false`     | Disables promotional banners and notices |
 | `WP_REDIS_DISABLE_COMMENT`           | `false`     | Disables HTML source comment |
-| `WP_REDIS_DISABLE_CHARTS`            | `false`     | Disables loading the ApexCharts script |
+| `WP_REDIS_LOAD_APEXCHARTS`           | `true`      | Whether to load the ApexCharts script |
 | `WP_REDIS_MANAGER_CAPABILITY`        |             | The capability a user must have to manage the plugin |
 
 </details>

--- a/includes/class-plugin.php
+++ b/includes/class-plugin.php
@@ -424,7 +424,7 @@ class Plugin {
             return;
         }
 
-        if ( ! defined( 'WP_REDIS_DISABLE_CHARTS' ) || ! WP_REDIS_DISABLE_CHARTS ) {
+        if ( ! defined( 'WP_REDIS_LOAD_APEXCHARTS' ) || WP_REDIS_LOAD_APEXCHARTS ) {
             wp_enqueue_script(
                 'redis-cache-charts',
                 plugins_url( 'assets/js/apexcharts.min.js', WP_REDIS_FILE ),


### PR DESCRIPTION
Invert the constant's semantics so the ApexCharts script loads by
default and is only skipped when the constant is explicitly false.

https://claude.ai/code/session_01Ftn1EzTvvG55Hkg7c3k6FQ