### PR TITLE
Improve UX for WP_REDIS_DISABLED constant configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Indicate when the cache is disabled via the `WP_REDIS_DISABLED` constant
 - Added `WP_REDIS_CHART_COLOR` constant
 - Added `WP_REDIS_LOAD_APEXCHARTS` constant
 - Upgrade ApexCharts to v4.7.0

--- a/includes/class-plugin.php
+++ b/includes/class-plugin.php
@@ -545,7 +545,7 @@ class Plugin {
         global $wp_object_cache;
 
         if ( defined( 'WP_REDIS_DISABLED' ) && WP_REDIS_DISABLED ) {
-            return __( 'Disabled', 'redis-cache' );
+            return __( 'Disabled (via config constant)', 'redis-cache' );
         }
 
         if ( ! $this->object_cache_dropin_exists() ) {

--- a/includes/ui/tabs/overview.php
+++ b/includes/ui/tabs/overview.php
@@ -52,7 +52,7 @@ $diagnostics = $roc->get_diagnostics();
                     <?php
                     printf(
                         // translators: %s = the WP_REDIS_DISABLED config constant, wrapped in a <code> tag.
-                        esc_html__( 'The object cache is disabled because the %s constant is set. Remove it from your configuration to re-enable the cache.', 'redis-cache' ),
+                        esc_html__( 'The object cache is disabled because the %s constant is set.', 'redis-cache' ),
                         '<code>WP_REDIS_DISABLED</code>'
                     );
                     ?>

--- a/includes/ui/tabs/overview.php
+++ b/includes/ui/tabs/overview.php
@@ -46,6 +46,18 @@ $diagnostics = $roc->get_diagnostics();
                     <?php echo esc_html( $roc->get_status() ); ?>
                 </span>
             <?php endif; ?>
+
+            <?php if ( defined( 'WP_REDIS_DISABLED' ) && WP_REDIS_DISABLED ) : ?>
+                <p class="description">
+                    <?php
+                    printf(
+                        // translators: %s = the WP_REDIS_DISABLED config constant, wrapped in a <code> tag.
+                        esc_html__( 'The object cache is disabled because the %s constant is set. Remove it from your configuration to re-enable the cache.', 'redis-cache' ),
+                        '<code>WP_REDIS_DISABLED</code>'
+                    );
+                    ?>
+                </p>
+            <?php endif; ?>
         </td>
     </tr>
 


### PR DESCRIPTION
## Summary
Enhanced user experience when the Redis object cache is disabled via the `WP_REDIS_DISABLED` configuration constant by providing clearer messaging and visual feedback in the admin interface.

## Key Changes
- Updated the status message from "Disabled" to "Disabled (via config constant)" to clarify the reason for disablement
- Added a descriptive notice in the overview tab that explains the `WP_REDIS_DISABLED` constant is active and instructs users how to re-enable the cache
- Updated CHANGELOG to document this improvement

## Implementation Details
- The notice appears conditionally only when `WP_REDIS_DISABLED` is defined and set to true
- The message includes proper escaping and translation support
- The constant name is wrapped in `<code>` tags for better visual distinction
- The notice provides actionable guidance to users on how to resolve the disabled state

https://claude.ai/code/session_01KGn56zEr2B6EZq47WBvcj9