### PR TITLE
Pin WordPress version 6.9 for PHP 7.2 and 7.3 compatibility

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -63,7 +63,7 @@ jobs:
       - name: Set up WordPress and WordPress Test Library
         uses: sjinks/setup-wordpress-test-library@master
         with:
-          version: latest
+          version: ${{ (matrix.php == '7.2' || matrix.php == '7.3') && '6.9' || 'latest' }}
           cache_prefix: redis-cache-${{ github.ref }}
 
       - name: Install PHP Dependencies
@@ -137,7 +137,7 @@ jobs:
       - name: Set up WordPress and WordPress Test Library
         uses: sjinks/setup-wordpress-test-library@master
         with:
-          version: latest
+          version: ${{ (matrix.php == '7.2' || matrix.php == '7.3') && '6.9' || 'latest' }}
           cache_prefix: redis-cache-${{ github.ref }}
 
       - name: Install PHP Dependencies


### PR DESCRIPTION
## Summary
Updated the WordPress test library setup to use WordPress 6.9 for PHP 7.2 and 7.3 environments, while maintaining the latest version for other PHP versions.

## Changes
- Modified the WordPress version configuration in both the main test job and the additional test job
- Added conditional logic to pin WordPress to version 6.9 when testing against PHP 7.2 or 7.3
- Other PHP versions continue to use the latest WordPress version

## Details
This change addresses compatibility issues with newer WordPress versions on older PHP versions. WordPress 6.9 is the last version to support PHP 7.2 and 7.3, so the workflow now explicitly uses this version for those PHP versions while allowing newer versions to test against the latest WordPress release.

The change was applied consistently across both test jobs in the workflow.

https://claude.ai/code/session_01GqoEe5sNsEJT9h6rFQkRs1