### PR TITLE
Upgrade Predis to v2.4.1 and add support for v3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Upgraded bundled Predis to v2.4.1
+- Allow Predis v3.0 as a Composer dependency
 - Indicate when the cache is disabled via the `WP_REDIS_DISABLED` constant
 - Added `WP_REDIS_CHART_COLOR` constant
 - Added `WP_REDIS_LOAD_APEXCHARTS` constant

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         "php": "^7.2 || ^8.0",
         "composer/installers": "~1.0 || ~2.0",
         "mnsami/composer-custom-directory-installer": "^2.0",
-        "predis/predis": "^1.1 || ^2.0",
+        "predis/predis": "^1.1 || ^2.0 || ^3.0",
         "colinmollenhour/credis": "^1.12.1"
     },
     "require-dev": {

--- a/dependencies/predis/predis/src/Client.php
+++ b/dependencies/predis/predis/src/Client.php
@@ -53,7 +53,7 @@ use Traversable;
  */
 class Client implements ClientInterface, IteratorAggregate
 {
-    public const VERSION = '2.4.0';
+    public const VERSION = '2.4.1';
 
     /** @var OptionsInterface */
     private $options;

--- a/dependencies/predis/predis/src/ClientInterface.php
+++ b/dependencies/predis/predis/src/ClientInterface.php
@@ -300,7 +300,7 @@ use Predis\Response\Status;
  * @method array|null        xread(int $count = null, int $block = null, array $streams = null, string ...$id)
  * @method int               zadd(string $key, array $membersAndScoresDictionary)
  * @method int               zcard(string $key)
- * @method string            zcount(string $key, int|string $min, int|string $max)
+ * @method int               zcount(string $key, int|string $min, int|string $max)
  * @method array             zdiff(array $keys, bool $withScores = false)
  * @method int               zdiffstore(string $destination, array $keys)
  * @method string            zincrby(string $key, int $increment, string $member)

--- a/dependencies/predis/predis/src/Connection/StreamConnection.php
+++ b/dependencies/predis/predis/src/Connection/StreamConnection.php
@@ -41,7 +41,6 @@ class StreamConnection extends AbstractConnection
     public function __construct(ParametersInterface $parameters)
     {
         parent::__construct($parameters);
-        $this->parameters->conn_uid = spl_object_hash($this);
     }
 
     /**


### PR DESCRIPTION
## Summary
This PR upgrades the bundled Predis library to v2.4.1 and extends Composer dependency constraints to allow Predis v3.0, while fixing a bug in the StreamConnection class and correcting a type hint in the ClientInterface.

## Key Changes
- **Upgraded bundled Predis** from v2.4.0 to v2.4.1
- **Extended Composer dependency constraint** to allow `predis/predis: ^1.1 || ^2.0 || ^3.0`
- **Fixed StreamConnection bug**: Removed the problematic `$this->parameters->conn_uid = spl_object_hash($this)` assignment that was causing issues with connection parameter handling
- **Corrected type hint**: Changed `zcount()` return type from `string` to `int` in ClientInterface to match the actual Redis command behavior

## Implementation Details
The StreamConnection constructor was unnecessarily setting a `conn_uid` parameter on the connection parameters object, which has been removed as it was not needed and could cause issues with parameter immutability or connection reuse.

The `zcount()` method type hint correction ensures proper type safety, as the Redis ZCOUNT command returns an integer count of elements, not a string.

https://claude.ai/code/session_01DoZtkQHX8kb9QVDQjp84Si